### PR TITLE
feat: Build & Push Docker Images with Dual Tagging

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -35,60 +35,67 @@ jobs:
           username: ${{ env.ACR_USERNAME }}
           password: ${{ env.ACR_PASSWORD }}
 
-      - name: Set Docker image tag with Date
+      - name: Set Docker image tags
+        id: tag
         run: |
-          echo "Determining tag for branch: ${{ github.ref }}"
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "TAG=latest-${{ steps.date.outputs.date }}" >> $GITHUB_ENV
-          elif [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
-            echo "TAG=dev-${{ steps.date.outputs.date }}" >> $GITHUB_ENV
-          elif [[ "${{ github.ref }}" == "refs/heads/demo" ]]; then
-            echo "TAG=demo-${{ steps.date.outputs.date }}" >> $GITHUB_ENV
-          elif [[ "${{ github.ref }}" == "refs/heads/hotfix" ]]; then
-            echo "TAG=hotfix-${{ steps.date.outputs.date }}" >> $GITHUB_ENV
+          BRANCH="${{ github.ref_name }}"
+          DATE="${{ steps.date.outputs.date }}"
+          if [[ "$BRANCH" == "main" ]]; then
+            BASE_TAG="latest"
+          elif [[ "$BRANCH" == "dev" ]]; then
+            BASE_TAG="dev"
+          elif [[ "$BRANCH" == "demo" ]]; then
+            BASE_TAG="demo"
+          elif [[ "$BRANCH" == "hotfix" ]]; then
+            BASE_TAG="hotfix"
           else
-            echo "TAG=pullrequest-ignore-${{ steps.date.outputs.date }}" >> $GITHUB_ENV
+            BASE_TAG="pullrequest-ignore"
           fi
-          echo "Tag set to: $TAG"
+          DATE_TAG="${BASE_TAG}-${DATE}"
+          echo "BASE_TAG=${BASE_TAG}" >> $GITHUB_ENV
+          echo "DATE_TAG=${DATE_TAG}" >> $GITHUB_ENV
+          echo "Base tag: $BASE_TAG, Date tag: $DATE_TAG"
 
       - name: Build and push ContentProcessor Docker image
         run: |
           cd src/ContentProcessor
-          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessor:${TAG}"
+          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessor"
           echo "Using image name: ${IMAGE_NAME}"
-          # Use the Dockerfile from the root folder of ContentProcessor
-          docker build -t ${IMAGE_NAME} -f Dockerfile .
-          if [[ "${TAG}" == latest-* || "${TAG}" == dev-* || "${TAG}" == demo-* || "${TAG}" == hotfix-* ]]; then
-            docker push ${IMAGE_NAME}
+          # Build image with two tags: one base and one with date
+          docker build -t ${IMAGE_NAME}:${BASE_TAG} -t ${IMAGE_NAME}:${DATE_TAG} -f Dockerfile .
+          # Push both tags if the base tag is valid
+          if [[ "${BASE_TAG}" == "latest" || "${BASE_TAG}" == "dev" || "${BASE_TAG}" == "demo" || "${BASE_TAG}" == "hotfix" ]]; then
+            docker push ${IMAGE_NAME}:${BASE_TAG}
+            docker push ${IMAGE_NAME}:${DATE_TAG}
             echo "ContentProcessor image built and pushed successfully."
           else
-            echo "Skipping Docker push for ContentProcessor with tag: ${TAG}"
+            echo "Skipping Docker push for ContentProcessor with tag: ${BASE_TAG}"
           fi
 
       - name: Build and push ContentProcessorAPI Docker image
         run: |
           cd src/ContentProcessorAPI
-          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessorapi:${TAG}"
+          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessorapi"
           echo "Using image name: ${IMAGE_NAME}"
-          # Use the Dockerfile from the root folder of ContentProcessorAPI
-          docker build -t ${IMAGE_NAME} -f Dockerfile .
-          if [[ "${TAG}" == latest-* || "${TAG}" == dev-* || "${TAG}" == demo-* || "${TAG}" == hotfix-* ]]; then
-            docker push ${IMAGE_NAME}
+          docker build -t ${IMAGE_NAME}:${BASE_TAG} -t ${IMAGE_NAME}:${DATE_TAG} -f Dockerfile .
+          if [[ "${BASE_TAG}" == "latest" || "${BASE_TAG}" == "dev" || "${BASE_TAG}" == "demo" || "${BASE_TAG}" == "hotfix" ]]; then
+            docker push ${IMAGE_NAME}:${BASE_TAG}
+            docker push ${IMAGE_NAME}:${DATE_TAG}
             echo "ContentProcessorAPI image built and pushed successfully."
           else
-            echo "Skipping Docker push for ContentProcessorAPI with tag: ${TAG}"
+            echo "Skipping Docker push for ContentProcessorAPI with tag: ${BASE_TAG}"
           fi
 
       - name: Build and push ContentProcessorWeb Docker image
         run: |
           cd src/ContentProcessorWeb
-          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessorweb:${TAG}"
+          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessorweb"
           echo "Using image name: ${IMAGE_NAME}"
-          # Use the Dockerfile from the root folder of ContentProcessorWeb
-          docker build -t ${IMAGE_NAME} -f Dockerfile .
-          if [[ "${TAG}" == latest-* || "${TAG}" == dev-* || "${TAG}" == demo-* || "${TAG}" == hotfix-* ]]; then
-            docker push ${IMAGE_NAME}
+          docker build -t ${IMAGE_NAME}:${BASE_TAG} -t ${IMAGE_NAME}:${DATE_TAG} -f Dockerfile .
+          if [[ "${BASE_TAG}" == "latest" || "${BASE_TAG}" == "dev" || "${BASE_TAG}" == "demo" || "${BASE_TAG}" == "hotfix" ]]; then
+            docker push ${IMAGE_NAME}:${BASE_TAG}
+            docker push ${IMAGE_NAME}:${DATE_TAG}
             echo "ContentProcessorWeb image built and pushed successfully."
           else
-            echo "Skipping Docker push for ContentProcessorWeb with tag: ${TAG}"
+            echo "Skipping Docker push for ContentProcessorWeb with tag: ${BASE_TAG}"
           fi

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -56,46 +56,32 @@ jobs:
           echo "DATE_TAG=${DATE_TAG}" >> $GITHUB_ENV
           echo "Base tag: $BASE_TAG, Date tag: $DATE_TAG"
 
-      - name: Build and push ContentProcessor Docker image
-        run: |
-          cd src/ContentProcessor
-          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessor"
-          echo "Using image name: ${IMAGE_NAME}"
-          # Build image with two tags: one base and one with date
-          docker build -t ${IMAGE_NAME}:${BASE_TAG} -t ${IMAGE_NAME}:${DATE_TAG} -f Dockerfile .
-          # Push both tags if the base tag is valid
-          if [[ "${BASE_TAG}" == "latest" || "${BASE_TAG}" == "dev" || "${BASE_TAG}" == "demo" || "${BASE_TAG}" == "hotfix" ]]; then
-            docker push ${IMAGE_NAME}:${BASE_TAG}
-            docker push ${IMAGE_NAME}:${DATE_TAG}
-            echo "ContentProcessor image built and pushed successfully."
-          else
-            echo "Skipping Docker push for ContentProcessor with tag: ${BASE_TAG}"
-          fi
+      - name: Build and Push ContentProcessor Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./src/ContentProcessor
+          file: ./src/ContentProcessor/Dockerfile
+          push: ${{ github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix' }}
+          tags: |
+            ${{ env.ACR_LOGIN_SERVER }}/contentprocessor:${{ env.BASE_TAG }}
+            ${{ env.ACR_LOGIN_SERVER }}/contentprocessor:${{ env.DATE_TAG }}
 
-      - name: Build and push ContentProcessorAPI Docker image
-        run: |
-          cd src/ContentProcessorAPI
-          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessorapi"
-          echo "Using image name: ${IMAGE_NAME}"
-          docker build -t ${IMAGE_NAME}:${BASE_TAG} -t ${IMAGE_NAME}:${DATE_TAG} -f Dockerfile .
-          if [[ "${BASE_TAG}" == "latest" || "${BASE_TAG}" == "dev" || "${BASE_TAG}" == "demo" || "${BASE_TAG}" == "hotfix" ]]; then
-            docker push ${IMAGE_NAME}:${BASE_TAG}
-            docker push ${IMAGE_NAME}:${DATE_TAG}
-            echo "ContentProcessorAPI image built and pushed successfully."
-          else
-            echo "Skipping Docker push for ContentProcessorAPI with tag: ${BASE_TAG}"
-          fi
+      - name: Build and Push ContentProcessorAPI Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./src/ContentProcessorAPI
+          file: ./src/ContentProcessorAPI/Dockerfile
+          push: ${{ github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix' }}
+          tags: |
+            ${{ env.ACR_LOGIN_SERVER }}/contentprocessorapi:${{ env.BASE_TAG }}
+            ${{ env.ACR_LOGIN_SERVER }}/contentprocessorapi:${{ env.DATE_TAG }}
 
-      - name: Build and push ContentProcessorWeb Docker image
-        run: |
-          cd src/ContentProcessorWeb
-          IMAGE_NAME="$ACR_LOGIN_SERVER/contentprocessorweb"
-          echo "Using image name: ${IMAGE_NAME}"
-          docker build -t ${IMAGE_NAME}:${BASE_TAG} -t ${IMAGE_NAME}:${DATE_TAG} -f Dockerfile .
-          if [[ "${BASE_TAG}" == "latest" || "${BASE_TAG}" == "dev" || "${BASE_TAG}" == "demo" || "${BASE_TAG}" == "hotfix" ]]; then
-            docker push ${IMAGE_NAME}:${BASE_TAG}
-            docker push ${IMAGE_NAME}:${DATE_TAG}
-            echo "ContentProcessorWeb image built and pushed successfully."
-          else
-            echo "Skipping Docker push for ContentProcessorWeb with tag: ${BASE_TAG}"
-          fi
+      - name: Build and Push ContentProcessorWeb Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./src/ContentProcessorWeb
+          file: ./src/ContentProcessorWeb/Dockerfile
+          push: ${{ github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix' }}
+          tags: |
+            ${{ env.ACR_LOGIN_SERVER }}/contentprocessorweb:${{ env.BASE_TAG }}
+            ${{ env.ACR_LOGIN_SERVER }}/contentprocessorweb:${{ env.DATE_TAG }}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This workflow triggers on pushes, pull requests, and manual dispatch for the main, dev, demo, and hotfix branches. It logs into Azure Container Registry conditionally, captures the current date, and sets two tags for each Docker image—one based on the branch (e.g., dev) and another appending the date (e.g., dev-2025-04-03). The images are built from the root directory of each project and pushed only for recognized branches.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

