### PR TITLE
feat: Add Create-Release Workflow Using Semantic Release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,64 @@
+name: Create-Release
+
+on:
+   push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+ 
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - uses: codfish/semantic-release-action@v3
+        id: semantic
+        with:
+          tag-format: 'v${version}'
+          additional-packages: |
+            ['conventional-changelog-conventionalcommits@7']
+          plugins: |
+            [
+              [
+                "@semantic-release/commit-analyzer",
+                {
+                  "preset": "conventionalcommits"
+                }
+              ],
+              [
+                "@semantic-release/release-notes-generator",
+                {
+                  "preset": "conventionalcommits",
+                  "presetConfig": {
+                    "types": [
+                      { type: 'feat', section: 'Features', hidden: false },
+                      { type: 'fix', section: 'Bug Fixes', hidden: false },
+                      { type: 'perf', section: 'Performance Improvements', hidden: false },
+                      { type: 'revert', section: 'Reverts', hidden: false },
+                      { type: 'docs', section: 'Other Updates', hidden: false },
+                      { type: 'style', section: 'Other Updates', hidden: false },
+                      { type: 'chore', section: 'Other Updates', hidden: false },
+                      { type: 'refactor', section: 'Other Updates', hidden: false },
+                      { type: 'test', section: 'Other Updates', hidden: false },
+                      { type: 'build', section: 'Other Updates', hidden: false },
+                      { type: 'ci', section: 'Other Updates', hidden: false }
+                    ]
+                  }
+                }
+              ],
+              '@semantic-release/github'
+            ]
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo ${{ steps.semantic.outputs.release-version }}
+
+      - run: echo "$OUTPUTS"
+        env:
+          OUTPUTS: ${{ toJson(steps.semantic.outputs) }}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR introduces a GitHub Actions workflow (create-release.yml) that automates semantic versioning and release note generation based on conventional commit messages. It uses the semantic-release toolset to:

- Analyze commit messages
- Generate changelogs
- Create GitHub releases

This helps ensure consistent release practices across the project and eliminates manual version bumps 
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


## What to Check
Verify that the following are valid

- The workflow is triggered only on push to the main branch.
- Proper permissions (contents and pull-requests) are granted.
- Uses the correct semantic-release plugins and presets.
- The GITHUB_TOKEN is correctly referenced from secrets.
- Workflow syntax and indentation are correct and valid.
- Confirm version tagging format as v${version}.
- Outputs of the release step are printed as expected.


