### PR TITLE
feat: Added templateName tag on rg

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -80,6 +80,16 @@ var resourceGroupLocation = resourceGroup().location
 // Load the abbrevations file required to name the azure resources.
 var abbrs = loadJsonContent('./abbreviations.json')
 
+// ========== Resource Group Tag ========== //
+resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
+  name: 'default'
+  properties: {
+    tags: {
+      templateName: 'Content Processing'
+    }
+  }
+}
+
 // ========== Managed Identity ========== //
 module managedIdentityModule 'deploy_managed_identity.bicep' = {
   name: 'deploy_managed_identity'

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.1.42791",
-      "templateHash": "2054400867460750387"
+      "version": "0.36.177.2456",
+      "templateHash": "9501869925039724025"
     }
   },
   "parameters": {
@@ -377,6 +377,16 @@
   },
   "resources": [
     {
+      "type": "Microsoft.Resources/tags",
+      "apiVersion": "2021-04-01",
+      "name": "default",
+      "properties": {
+        "tags": {
+          "templateName": "Content Processing"
+        }
+      }
+    },
+    {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "deploy_managed_identity",
@@ -403,8 +413,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "17040083292589011391"
+              "version": "0.36.177.2456",
+              "templateHash": "16013228479747802521"
             }
           },
           "parameters": {
@@ -489,8 +499,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "11049431112452456133"
+              "version": "0.36.177.2456",
+              "templateHash": "2678512499745531561"
             }
           },
           "parameters": {
@@ -598,8 +608,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1305630352036876197"
+              "version": "0.36.177.2456",
+              "templateHash": "11861975053716689304"
             }
           },
           "parameters": {
@@ -708,8 +718,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "3200993772301267162"
+              "version": "0.36.177.2456",
+              "templateHash": "13663159429619963596"
             }
           },
           "parameters": {
@@ -854,8 +864,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "13978305638370067003"
+              "version": "0.36.177.2456",
+              "templateHash": "5697127376222034539"
             }
           },
           "parameters": {
@@ -1296,8 +1306,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "17443204944330265380"
+              "version": "0.36.177.2456",
+              "templateHash": "13431796479668514064"
             }
           },
           "parameters": {
@@ -1437,8 +1447,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "10338800926086953929"
+              "version": "0.36.177.2456",
+              "templateHash": "5913704217630308199"
             }
           },
           "parameters": {
@@ -1838,8 +1848,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "8984863566776850276"
+                      "version": "0.36.177.2456",
+                      "templateHash": "12587924580946144671"
                     }
                   },
                   "parameters": {
@@ -2011,8 +2021,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "8984863566776850276"
+                      "version": "0.36.177.2456",
+                      "templateHash": "12587924580946144671"
                     }
                   },
                   "parameters": {
@@ -2196,8 +2206,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "8984863566776850276"
+                      "version": "0.36.177.2456",
+                      "templateHash": "12587924580946144671"
                     }
                   },
                   "parameters": {
@@ -2376,8 +2386,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "3850312828243192450"
+              "version": "0.36.177.2456",
+              "templateHash": "9030802815363800309"
             }
           },
           "parameters": {
@@ -2484,8 +2494,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "10346977865586942127"
+              "version": "0.36.177.2456",
+              "templateHash": "15747383464320468775"
             }
           },
           "parameters": {
@@ -2726,8 +2736,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "1992580664978730799"
+              "version": "0.36.177.2456",
+              "templateHash": "17800868183604157395"
             }
           },
           "parameters": {
@@ -2926,8 +2936,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.1.42791",
-              "templateHash": "10338800926086953929"
+              "version": "0.36.177.2456",
+              "templateHash": "5913704217630308199"
             }
           },
           "parameters": {
@@ -3327,8 +3337,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "8984863566776850276"
+                      "version": "0.36.177.2456",
+                      "templateHash": "12587924580946144671"
                     }
                   },
                   "parameters": {
@@ -3500,8 +3510,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "8984863566776850276"
+                      "version": "0.36.177.2456",
+                      "templateHash": "12587924580946144671"
                     }
                   },
                   "parameters": {
@@ -3685,8 +3695,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.36.1.42791",
-                      "templateHash": "8984863566776850276"
+                      "version": "0.36.177.2456",
+                      "templateHash": "12587924580946144671"
                     }
                   },
                   "parameters": {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
This pull request introduces a new resource group tagging mechanism in the `infra` module and updates the metadata in the generated JSON files to reflect a newer version of the Bicep compiler. The most significant changes are the addition of the resource group tags and the associated updates in the JSON files.

### Resource Group Tagging:

* Added a new resource definition (`resourceGroupTags`) in `infra/main.bicep` to apply a default tag (`templateName: 'Content Processing'`) to the resource group.
* Added the corresponding resource group tag definition in the generated `infra/main.json` file.

### Metadata Updates:

* Updated the `_generator` metadata in `infra/main.json` to reflect the Bicep compiler version change from `0.36.1.42791` to `0.36.177.2456`. This change is repeated across multiple sections of the file to ensure consistency. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L406-R417) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L492-R503) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L601-R612) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L711-R722) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L857-R868) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1299-R1310) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1440-R1451) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1841-R1852) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2014-R2025) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2199-R2210) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2379-R2390) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2487-R2498) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2729-R2740) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2929-R2940) [[16]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3330-R3341) [[17]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3503-R3514) [[18]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3688-R3699)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

