### PR TITLE
fix: add principalType as 'ServicePrincipal' for role assignments

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -447,6 +447,7 @@ module avmKeyVault './modules/key-vault.bicep' = {
       {
         principalId: avmManagedIdentity.outputs.principalId
         roleDefinitionIdOrName: 'Key Vault Administrator'
+        principalType: 'ServicePrincipal'
       }
     ]
     enablePurgeProtection: false
@@ -503,6 +504,7 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.20.0' = {
       {
         principalId: avmManagedIdentity.outputs.principalId
         roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        principalType: 'ServicePrincipal'
       }
       {
         roleDefinitionIdOrName: 'Storage Blob Data Contributor'
@@ -598,6 +600,7 @@ module avmAiServices 'modules/account/main.bicep' = {
       {
         principalId: avmManagedIdentity.outputs.principalId
         roleDefinitionIdOrName: '8e3af657-a8ff-443c-a75c-2fe8c4bcb635' // Owner role
+        principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
@@ -1089,14 +1092,17 @@ module avmAppConfig 'br/public:avm/res/app-configuration/configuration-store:0.6
       {
         principalId: avmContainerApp.outputs.?systemAssignedMIPrincipalId!
         roleDefinitionIdOrName: 'App Configuration Data Reader'
+        principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_API.outputs.?systemAssignedMIPrincipalId!
         roleDefinitionIdOrName: 'App Configuration Data Reader'
+        principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Web.outputs.?systemAssignedMIPrincipalId!
         roleDefinitionIdOrName: 'App Configuration Data Reader'
+        principalType: 'ServicePrincipal'
       }
     ]
     keyValues: [

--- a/infra/main.json
+++ b/infra/main.json
@@ -255,7 +255,7 @@
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
               }
             ]
           },
@@ -935,7 +935,7 @@
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
               }
             ]
           },
@@ -1680,7 +1680,7 @@
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
               }
             ]
           },
@@ -2360,7 +2360,7 @@
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
               }
             ]
           },
@@ -3045,7 +3045,7 @@
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
               }
             ]
           },
@@ -11024,15 +11024,15 @@
           "outputs": {
             "resourceId": {
               "type": "string",
-              "value": "[if(variables('useExistingWorkspace'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingLawSubscription'), variables('existingLawResourceGroup')), 'Microsoft.OperationalInsights/workspaces', variables('existingLawName')), reference('logAnalyticsWorkspace').outputs.resourceId.value)]"
+              "value": "[if(variables('useExistingWorkspace'), extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingLawSubscription'), variables('existingLawResourceGroup')), 'Microsoft.OperationalInsights/workspaces', variables('existingLawName')), listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_new_log_analytics_workspace'), '2022-09-01').resourceId)]"
             },
             "logAnalyticsWorkspaceId": {
               "type": "string",
-              "value": "[if(variables('useExistingWorkspace'), reference('existingLogAnalyticsWorkspace').customerId, reference('logAnalyticsWorkspace').outputs.logAnalyticsWorkspaceId.value)]"
+              "value": "[if(variables('useExistingWorkspace'), reference('existingLogAnalyticsWorkspace').customerId, listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_new_log_analytics_workspace'), '2022-09-01').logAnalyticsWorkspaceId)]"
             },
             "primarySharedKey": {
               "type": "securestring",
-              "value": "[if(variables('useExistingWorkspace'), if(variables('useExistingWorkspace'), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingLawSubscription'), variables('existingLawResourceGroup')), 'Microsoft.OperationalInsights/workspaces', variables('existingLawName')), '2020-08-01'), listOutputsWithSecureValues('logAnalyticsWorkspace', '2022-09-01').primarySharedKey).primarySharedKey, listOutputsWithSecureValues('logAnalyticsWorkspace', '2022-09-01').primarySharedKey)]"
+              "value": "[if(variables('useExistingWorkspace'), if(variables('useExistingWorkspace'), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingLawSubscription'), variables('existingLawResourceGroup')), 'Microsoft.OperationalInsights/workspaces', variables('existingLawName')), '2020-08-01'), listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_new_log_analytics_workspace'), '2022-09-01').primarySharedKey).primarySharedKey, listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_new_log_analytics_workspace'), '2022-09-01').primarySharedKey)]"
             }
           }
         }
@@ -11055,12 +11055,12 @@
             "value": "[parameters('location')]"
           },
           "workspaceResourceId": {
-            "value": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+            "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
           },
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
               }
             ]
           },
@@ -12335,7 +12335,8 @@
             "value": [
               {
                 "principalId": "[reference('avmManagedIdentity').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "Key Vault Administrator"
+                "roleDefinitionIdOrName": "Key Vault Administrator",
+                "principalType": "ServicePrincipal"
               }
             ]
           },
@@ -12368,7 +12369,7 @@
           },
           "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
           "logAnalyticsWorkspaceResourceId": {
-            "value": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+            "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
           },
           "networkAcls": {
             "value": {
@@ -19157,7 +19158,8 @@
             "value": [
               {
                 "principalId": "[reference('avmManagedIdentity').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor"
+                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "principalType": "ServicePrincipal"
               },
               {
                 "roleDefinitionIdOrName": "Storage Blob Data Contributor",
@@ -24952,7 +24954,7 @@
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]"
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]"
               }
             ]
           },
@@ -24960,7 +24962,8 @@
             "value": [
               {
                 "principalId": "[reference('avmManagedIdentity').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+                "roleDefinitionIdOrName": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+                "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('avmContainerApp').outputs.systemAssignedMIPrincipalId.value]",
@@ -26259,7 +26262,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.36.177.2456",
-                      "templateHash": "11270933172961789567"
+                      "templateHash": "4128376395637895528"
                     }
                   },
                   "definitions": {
@@ -28068,7 +28071,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.36.177.2456",
-                              "templateHash": "9150529619101779014"
+                              "templateHash": "1200612323329026557"
                             }
                           },
                           "definitions": {
@@ -30643,9 +30646,9 @@
       "dependsOn": [
         "avmContainerApp",
         "avmManagedIdentity",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').contentUnderstanding)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').contentUnderstanding)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "avmVirtualNetwork",
         "logAnalyticsWorkspace"
@@ -33020,8 +33023,8 @@
             "value": {
               "destination": "log-analytics",
               "logAnalyticsConfiguration": {
-                "customerId": "[reference('logAnalyticsWorkspace').outputs.logAnalyticsWorkspaceId.value]",
-                "sharedKey": "[listOutputsWithSecureValues('logAnalyticsWorkspace', '2022-09-01').primarySharedKey]"
+                "customerId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').logAnalyticsWorkspaceId]",
+                "sharedKey": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').primarySharedKey]"
               }
             }
           },
@@ -42901,7 +42904,7 @@
           "diagnosticSettings": {
             "value": [
               {
-                "workspaceResourceId": "[reference('logAnalyticsWorkspace').outputs.resourceId.value]",
+                "workspaceResourceId": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'deploy_log_analytics_workspace'), '2022-09-01').resourceId]",
                 "logCategoriesAndGroups": [
                   {
                     "categoryGroup": "allLogs",
@@ -42919,15 +42922,18 @@
             "value": [
               {
                 "principalId": "[tryGet(tryGet(reference('avmContainerApp').outputs, 'systemAssignedMIPrincipalId'), 'value')]",
-                "roleDefinitionIdOrName": "App Configuration Data Reader"
+                "roleDefinitionIdOrName": "App Configuration Data Reader",
+                "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[tryGet(tryGet(reference('avmContainerApp_API').outputs, 'systemAssignedMIPrincipalId'), 'value')]",
-                "roleDefinitionIdOrName": "App Configuration Data Reader"
+                "roleDefinitionIdOrName": "App Configuration Data Reader",
+                "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[tryGet(tryGet(reference('avmContainerApp_Web').outputs, 'systemAssignedMIPrincipalId'), 'value')]",
-                "roleDefinitionIdOrName": "App Configuration Data Reader"
+                "roleDefinitionIdOrName": "App Configuration Data Reader",
+                "principalType": "ServicePrincipal"
               }
             ]
           },
@@ -42999,11 +43005,11 @@
               },
               {
                 "name": "APP_STORAGE_BLOB_URL",
-                "value": "[reference('avmStorageAccount').outputs.serviceEndpoints.value.blob]"
+                "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', format(parameters('resourceNameFormatString'), 'st')), '2022-09-01').serviceEndpoints.blob]"
               },
               {
                 "name": "APP_STORAGE_QUEUE_URL",
-                "value": "[reference('avmStorageAccount').outputs.serviceEndpoints.value.queue]"
+                "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', format(parameters('resourceNameFormatString'), 'st')), '2022-09-01').serviceEndpoints.queue]"
               },
               {
                 "name": "APP_AI_PROJECT_ENDPOINT",
@@ -43011,7 +43017,7 @@
               },
               {
                 "name": "APP_COSMOS_CONNSTR",
-                "value": "[listOutputsWithSecureValues('avmCosmosDB', '2022-09-01').primaryReadWriteConnectionString]"
+                "value": "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', format(parameters('resourceNameFormatString'), 'cosmos-')), '2022-09-01').primaryReadWriteConnectionString]"
               }
             ]
           },


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces updates to the Azure infrastructure deployment files (`infra/main.bicep` and `infra/main.json`) to improve security and functionality. The key changes include the addition of `principalType: 'ServicePrincipal'` across multiple role assignments and the replacement of outdated `reference()` calls with `listOutputsWithSecureValues()` for secure resource access.

### Updates to Role Assignments:
* Added `principalType: 'ServicePrincipal'` to role assignments in `infra/main.bicep` for modules such as `avmKeyVault`, `avmStorageAccount`, `avmAiServices`, and `avmAppConfig`. This ensures the correct principal type is used for service roles. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R450) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R507) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R603) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1095-R1105)
* Applied similar updates in `infra/main.json` for roles such as `Key Vault Administrator`, `Storage Blob Data Contributor`, and `App Configuration Data Reader`. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L12338-R12339) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19160-R19162) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L42922-R42936)

### Secure Resource Access:
* Replaced `reference()` calls with `listOutputsWithSecureValues()` for accessing resources like Log Analytics Workspace and Storage Account in `infra/main.json`. This improves security by using secure values for outputs. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L258-R258) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L938-R938) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L43002-R43020)

### Miscellaneous Improvements:
* Updated template hashes in `infra/main.json` to reflect changes in the deployment templates. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L26262-R26265) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L28071-R28074)
* Fixed dependency order in `infra/main.json` for private DNS zones to ensure proper sequencing.

These changes enhance the security and maintainability of the infrastructure code while ensuring compatibility with updated Azure resource configurations.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

