### PR TITLE
feat: Use ManagedIdentityCredential fir Prod Workloads and DefaultAzureCredential for dev

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -807,6 +807,10 @@ module avmContainerApp 'br/public:avm/res/app/container-app:0.17.0' = {
             name: 'APP_CONFIG_ENDPOINT'
             value: ''
           }
+          {
+            name: 'APP_ENV'
+            value: 'prod'
+          }
         ]
       }
     ]
@@ -850,6 +854,10 @@ module avmContainerApp_API 'br/public:avm/res/app/container-app:0.17.0' = {
           {
             name: 'APP_CONFIG_ENDPOINT'
             value: ''
+          }
+          {
+            name: 'APP_ENV'
+            value: 'prod'
           }
         ]
         probes: [
@@ -1266,6 +1274,10 @@ module avmContainerApp_update 'br/public:avm/res/app/container-app:0.17.0' = {
             name: 'APP_CONFIG_ENDPOINT'
             value: avmAppConfig.outputs.endpoint
           }
+          {
+            name: 'APP_ENV'
+            value: 'prod'
+          }
         ]
       }
     ]
@@ -1320,6 +1332,10 @@ module avmContainerApp_API_update 'br/public:avm/res/app/container-app:0.17.0' =
           {
             name: 'APP_CONFIG_ENDPOINT'
             value: avmAppConfig.outputs.endpoint
+          }
+          {
+            name: 'APP_ENV'
+            value: 'prod'
           }
         ]
         probes: [

--- a/src/ContentProcessor/conftest.py
+++ b/src/ContentProcessor/conftest.py
@@ -1,0 +1,34 @@
+"""
+Global test configuration and fixtures for ContentProcessor tests.
+"""
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Add src directory to Python path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+pytest_plugins = ["pytest_mock"]
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mock_azure_credentials_for_helpers(request):
+    """
+    Mock Azure credentials for azure_helper classes only.
+    Skip this for credential utility tests that need to test the actual logic.
+    """
+    # Skip mocking for credential utility tests
+    if "test_azure_credential_utils" in str(request.fspath):
+        yield
+        return
+
+    with patch("helpers.azure_credential_utils.get_azure_credential") as mock_get_cred, \
+         patch("helpers.azure_credential_utils.get_azure_credential_async") as mock_get_cred_async:
+
+        # Create mock credential objects
+        mock_credential = MagicMock()
+        mock_get_cred.return_value = mock_credential
+        mock_get_cred_async.return_value = mock_credential
+
+        yield mock_credential

--- a/src/ContentProcessor/pytest.ini
+++ b/src/ContentProcessor/pytest.ini
@@ -1,0 +1,6 @@
+[tool:pytest]
+addopts = -v --strict-markers --disable-warnings
+python_files = tests.py test_*.py *_tests.py
+testpaths = src/tests
+markers =
+    asyncio: marks tests as async

--- a/src/ContentProcessor/src/helpers/azure_credential_utils.py
+++ b/src/ContentProcessor/src/helpers/azure_credential_utils.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+from azure.identity import ManagedIdentityCredential, DefaultAzureCredential
+from azure.identity.aio import ManagedIdentityCredential as AioManagedIdentityCredential, DefaultAzureCredential as AioDefaultAzureCredential
+
+
+async def get_azure_credential_async(client_id=None):
+    """
+    Returns an Azure credential asynchronously based on the application environment.
+
+    If the environment is 'dev', it uses AioDefaultAzureCredential.
+    Otherwise, it uses AioManagedIdentityCredential.
+
+    Args:
+        client_id (str, optional): The client ID for the Managed Identity Credential.
+
+    Returns:
+        Credential object: Either AioDefaultAzureCredential or AioManagedIdentityCredential.
+    """
+    if os.getenv("APP_ENV", "prod").lower() == 'dev':
+        return AioDefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+    else:
+        return AioManagedIdentityCredential(client_id=client_id)
+
+
+def get_azure_credential(client_id=None):
+    """
+    Returns an Azure credential based on the application environment.
+
+    If the environment is 'dev', it uses DefaultAzureCredential.
+    Otherwise, it uses ManagedIdentityCredential.
+
+    Args:
+        client_id (str, optional): The client ID for the Managed Identity Credential.
+
+    Returns:
+        Credential object: Either DefaultAzureCredential or ManagedIdentityCredential.
+    """
+    if os.getenv("APP_ENV", "prod").lower() == 'dev':
+        return DefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+    else:
+        return ManagedIdentityCredential(client_id=client_id)

--- a/src/ContentProcessor/src/libs/application/application_context.py
+++ b/src/ContentProcessor/src/libs/application/application_context.py
@@ -1,4 +1,6 @@
-from azure.identity import DefaultAzureCredential
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+from typing import Any
 
 from libs.application.application_configuration import AppConfiguration
 from libs.base.application_models import AppModelBase
@@ -11,10 +13,10 @@ class AppContext(AppModelBase):
     """
 
     configuration: AppConfiguration = None
-    credential: DefaultAzureCredential = None
+    credential: Any = None  # Azure credential object
 
     def set_configuration(self, configuration: AppConfiguration):
         self.configuration = configuration
 
-    def set_credential(self, credential: DefaultAzureCredential):
+    def set_credential(self, credential: Any):
         self.credential = credential

--- a/src/ContentProcessor/src/libs/azure_helper/app_configuration.py
+++ b/src/ContentProcessor/src/libs/azure_helper/app_configuration.py
@@ -1,16 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import os
 
 from azure.appconfiguration import AzureAppConfigurationClient
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 
 
 class AppConfigurationHelper:
-    credential: DefaultAzureCredential = None
     app_config_endpoint: str = None
     app_config_client: AzureAppConfigurationClient = None
 
     def __init__(self, app_config_endpoint: str):
-        self.credential = DefaultAzureCredential()
+        self.credential = get_azure_credential()
         self.app_config_endpoint = app_config_endpoint
         self._initialize_client()
 

--- a/src/ContentProcessor/src/libs/azure_helper/azure_openai.py
+++ b/src/ContentProcessor/src/libs/azure_helper/azure_openai.py
@@ -1,9 +1,13 @@
-from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from azure.identity import get_bearer_token_provider
+from helpers.azure_credential_utils import get_azure_credential
 from openai import AzureOpenAI
 
 
 def get_openai_client(azure_openai_endpoint: str) -> AzureOpenAI:
-    credential = DefaultAzureCredential()
+    credential = get_azure_credential()
     token_provider = get_bearer_token_provider(
         credential, "https://cognitiveservices.azure.com/.default"
     )

--- a/src/ContentProcessor/src/libs/azure_helper/content_understanding.py
+++ b/src/ContentProcessor/src/libs/azure_helper/content_understanding.py
@@ -7,14 +7,13 @@ import time
 from pathlib import Path
 
 import requests
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 from requests.models import Response
 
 COGNITIVE_SERVICES_SCOPE = "https://cognitiveservices.azure.com/.default"
 
 
 class AzureContentUnderstandingHelper:
-    credential: DefaultAzureCredential = None
 
     def __init__(
         self,
@@ -22,7 +21,7 @@ class AzureContentUnderstandingHelper:
         api_version: str = "2024-12-01-preview",
         x_ms_useragent: str = "cps-contentunderstanding/client",
     ):
-        self.credential = DefaultAzureCredential()
+        self.credential = get_azure_credential()
 
         if not api_version:
             raise ValueError("API version must be provided.")

--- a/src/ContentProcessor/src/libs/azure_helper/storage_blob.py
+++ b/src/ContentProcessor/src/libs/azure_helper/storage_blob.py
@@ -3,12 +3,11 @@
 
 from typing import IO, Union
 
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 from azure.storage.blob import BlobServiceClient
 
 
 class StorageBlobHelper:
-    credential: DefaultAzureCredential = None
     blob_service_client: BlobServiceClient = None
 
     @staticmethod
@@ -16,7 +15,7 @@ class StorageBlobHelper:
         return StorageBlobHelper(account_url=account_url, container_name=container_name)
 
     def __init__(self, account_url: str, container_name=None):
-        self.credential = DefaultAzureCredential()
+        self.credential = get_azure_credential()
         self.blob_service_client = BlobServiceClient(
             account_url=account_url, credential=self.credential
         )

--- a/src/ContentProcessor/src/libs/pipeline/pipeline_queue_helper.py
+++ b/src/ContentProcessor/src/libs/pipeline/pipeline_queue_helper.py
@@ -4,7 +4,7 @@
 import logging
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 from azure.storage.queue import QueueClient, QueueMessage
 
 from libs.pipeline import pipeline_step_helper
@@ -28,7 +28,7 @@ def invalidate_queue(queue_client: QueueClient):
 
 
 def create_or_get_queue_client(
-    queue_name: str, accouont_url: str, credential: DefaultAzureCredential
+    queue_name: str, accouont_url: str, credential: get_azure_credential
 ) -> QueueClient:
     queue_client = QueueClient(
         account_url=accouont_url, queue_name=queue_name, credential=credential
@@ -55,7 +55,7 @@ def has_messages(queue_client: QueueClient) -> bool:
 
 
 def pass_data_pipeline_to_next_step(
-    data_pipeline: DataPipeline, account_url: str, credential: DefaultAzureCredential
+    data_pipeline: DataPipeline, account_url: str, credential: get_azure_credential
 ):
     next_step_name = pipeline_step_helper.get_next_step_name(
         data_pipeline.pipeline_status, data_pipeline.pipeline_status.active_step
@@ -70,7 +70,7 @@ def pass_data_pipeline_to_next_step(
 
 
 def _create_queue_client(
-    account_url: str, queue_name: str, credential: DefaultAzureCredential
+    account_url: str, queue_name: str, credential: get_azure_credential
 ) -> QueueClient:
     queue_client = QueueClient(
         account_url=account_url, queue_name=queue_name, credential=credential

--- a/src/ContentProcessor/src/libs/utils/remote_module_loader.py
+++ b/src/ContentProcessor/src/libs/utils/remote_module_loader.py
@@ -4,7 +4,7 @@
 import importlib.util
 import sys
 
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 from azure.storage.blob import BlobServiceClient
 
 
@@ -27,7 +27,7 @@ def load_schema_from_blob(
 
 def _download_blob_content(container_name, blob_name, account_url):
     # Create the BlobServiceClient object which will be used to create a container client
-    credential = DefaultAzureCredential()
+    credential = get_azure_credential()
     blob_service_client = BlobServiceClient(
         account_url=account_url, credential=credential
     )

--- a/src/ContentProcessor/src/main.py
+++ b/src/ContentProcessor/src/main.py
@@ -5,7 +5,7 @@ import asyncio
 import os
 import sys
 
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 
 from libs.base.application_main import AppMainBase
 from libs.process_host import handler_type_loader
@@ -29,7 +29,7 @@ class Application(AppMainBase):
 
     def _initialize_application(self):
         # Add Azure Credential
-        self.application_context.set_credential(DefaultAzureCredential())
+        self.application_context.set_credential(get_azure_credential())
 
     async def run(self, test_mode: bool = False):
         # Get Process lists from the configuration - ex. ["extract", "transform", "evaluate", "save", "custom1", "custom2"....]

--- a/src/ContentProcessor/src/tests/azure_helper/test_storage_blob.py
+++ b/src/ContentProcessor/src/tests/azure_helper/test_storage_blob.py
@@ -1,20 +1,22 @@
 import pytest
 from io import BytesIO
-from libs.azure_helper.storage_blob import StorageBlobHelper
+from unittest.mock import MagicMock, patch
+
+# Ensure Azure credentials are mocked before any imports
+with patch("helpers.azure_credential_utils.get_azure_credential") as mock_cred:
+    mock_cred.return_value = MagicMock()
+    from libs.azure_helper.storage_blob import StorageBlobHelper
 
 
 @pytest.fixture
 def mock_blob_service_client(mocker):
+    """Mock BlobServiceClient class for tests."""
     return mocker.patch("libs.azure_helper.storage_blob.BlobServiceClient")
 
 
 @pytest.fixture
-def mock_default_azure_credential(mocker):
-    return mocker.patch("libs.azure_helper.storage_blob.DefaultAzureCredential")
-
-
-@pytest.fixture
-def storage_blob_helper(mock_blob_service_client, mock_default_azure_credential):
+def storage_blob_helper(mock_blob_service_client):
+    """Create StorageBlobHelper with mocked BlobServiceClient."""
     return StorageBlobHelper(
         account_url="https://testaccount.blob.core.windows.net",
         container_name="testcontainer",

--- a/src/ContentProcessor/src/tests/conftest.py
+++ b/src/ContentProcessor/src/tests/conftest.py
@@ -1,0 +1,4 @@
+"""
+Test configuration and fixtures for ContentProcessor tests.
+"""
+# Note: pytest_plugins is now defined in the top-level conftest.py

--- a/src/ContentProcessor/src/tests/helpers/test_azure_credential_utils.py
+++ b/src/ContentProcessor/src/tests/helpers/test_azure_credential_utils.py
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+# Ensure src directory is on the Python path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+# Import after path modification (flake8: noqa)
+import helpers.azure_credential_utils as azure_credential_utils  # noqa: E402
+
+
+# Synchronous tests
+
+
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_dev_env(mock_managed_identity_credential, mock_default_azure_credential, mock_getenv):
+    """Test get_azure_credential in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_default_credential = MagicMock()
+    mock_default_azure_credential.return_value = mock_default_credential
+
+    credential = azure_credential_utils.get_azure_credential()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_default_azure_credential.assert_called_once()
+    mock_managed_identity_credential.assert_not_called()
+    assert credential == mock_default_credential
+
+
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_non_dev_env(mock_managed_identity_credential, mock_default_azure_credential, mock_getenv):
+    """Test get_azure_credential in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_managed_credential = MagicMock()
+    mock_managed_identity_credential.return_value = mock_managed_credential
+    credential = azure_credential_utils.get_azure_credential(client_id="test-client-id")
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
+    mock_default_azure_credential.assert_not_called()
+    assert credential == mock_managed_credential
+
+
+# Asynchronous tests
+
+
+@pytest.mark.asyncio
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_dev_env(mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv):
+    """Test get_azure_credential_async in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_aio_default_credential = MagicMock()
+    mock_aio_default_azure_credential.return_value = mock_aio_default_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_default_azure_credential.assert_called_once()
+    mock_aio_managed_identity_credential.assert_not_called()
+    assert credential == mock_aio_default_credential
+
+
+@pytest.mark.asyncio
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_non_dev_env(mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv):
+    """Test get_azure_credential_async in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_aio_managed_credential = MagicMock()
+    mock_aio_managed_identity_credential.return_value = mock_aio_managed_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async(client_id="test-client-id")
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
+    mock_aio_default_azure_credential.assert_not_called()
+    assert credential == mock_aio_managed_credential

--- a/src/ContentProcessor/src/tests/test_main.py
+++ b/src/ContentProcessor/src/tests/test_main.py
@@ -36,8 +36,7 @@ async def test_application_run(mocker):
         "libs.process_host.handler_process_host.HandlerHostManager"
     ).return_value
 
-    # Mock the DefaultAzureCredential
-    mocker.patch("azure.identity.DefaultAzureCredential")
+    # Note: Azure credentials are mocked globally via conftest.py
 
     # Mock the read_configuration method to return a complete configuration
     mocker.patch(

--- a/src/ContentProcessorAPI/app/.env.dev
+++ b/src/ContentProcessorAPI/app/.env.dev
@@ -1,0 +1,9 @@
+# Development Environment Configuration
+# Set to 'dev' to use DefaultAzureCredential for local development
+# Set to 'prod' to use ManagedIdentityCredential for production deployment
+APP_ENV=dev
+
+# Add other API development configuration here as needed
+# AZURE_STORAGE_ACCOUNT_URL=
+# AZURE_APP_CONFIG_ENDPOINT=
+# API_PORT=8000

--- a/src/ContentProcessorAPI/app/libs/app_configuration/helper.py
+++ b/src/ContentProcessorAPI/app/libs/app_configuration/helper.py
@@ -4,16 +4,15 @@
 import os
 
 from azure.appconfiguration import AzureAppConfigurationClient
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 
 
 class AppConfigurationHelper:
-    credential: DefaultAzureCredential = None
     app_config_endpoint: str = None
     app_config_client: AzureAppConfigurationClient = None
 
     def __init__(self, app_config_endpoint: str):
-        self.credential = DefaultAzureCredential()
+        self.credential = get_azure_credential()
         self.app_config_endpoint = app_config_endpoint
         self._initialize_client()
 

--- a/src/ContentProcessorAPI/app/libs/storage_blob/helper.py
+++ b/src/ContentProcessorAPI/app/libs/storage_blob/helper.py
@@ -1,13 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 from azure.storage.blob import BlobServiceClient
 
 
 class StorageBlobHelper:
     def __init__(self, account_url, container_name=None):
-        credential = DefaultAzureCredential()
+        credential = get_azure_credential()
         self.blob_service_client = BlobServiceClient(
             account_url=account_url, credential=credential
         )

--- a/src/ContentProcessorAPI/app/libs/storage_queue/helper.py
+++ b/src/ContentProcessorAPI/app/libs/storage_queue/helper.py
@@ -4,14 +4,14 @@
 import logging
 
 from azure.core.exceptions import ResourceNotFoundError
-from azure.identity import DefaultAzureCredential
+from helpers.azure_credential_utils import get_azure_credential
 from azure.storage.queue import QueueClient
 from pydantic import BaseModel
 
 
 class StorageQueueHelper:
     def __init__(self, account_url, queue_name):
-        credential = DefaultAzureCredential()
+        credential = get_azure_credential()
         self.queue_client = self.create_or_get_queue_client(
             queue_name=queue_name, accouont_url=account_url, credential=credential
         )
@@ -27,7 +27,7 @@ class StorageQueueHelper:
             queue_client.create_queue()
 
     def create_or_get_queue_client(
-        self, queue_name: str, accouont_url: str, credential: DefaultAzureCredential
+        self, queue_name: str, accouont_url: str, credential: get_azure_credential
     ) -> QueueClient:
         queue_client = QueueClient(
             account_url=accouont_url, queue_name=queue_name, credential=credential

--- a/src/ContentProcessorAPI/app/tests/libs/test_storage_blob.py
+++ b/src/ContentProcessorAPI/app/tests/libs/test_storage_blob.py
@@ -1,7 +1,12 @@
 import pytest
 from azure.storage.blob import BlobServiceClient, ContainerClient, BlobClient
 from azure.core.exceptions import ResourceNotFoundError
-from app.libs.storage_blob.helper import StorageBlobHelper
+from unittest.mock import MagicMock, patch
+
+# Ensure Azure credentials are mocked before any imports
+with patch("helpers.azure_credential_utils.get_azure_credential") as mock_cred:
+    mock_cred.return_value = MagicMock()
+    from app.libs.storage_blob.helper import StorageBlobHelper
 
 
 @pytest.fixture

--- a/src/ContentProcessorAPI/conftest.py
+++ b/src/ContentProcessorAPI/conftest.py
@@ -1,0 +1,34 @@
+"""
+Global test configuration and fixtures for ContentProcessorAPI tests.
+"""
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Add current directory to Python path for imports
+sys.path.insert(0, os.path.dirname(__file__))
+
+pytest_plugins = ["pytest_mock"]
+
+
+@pytest.fixture(autouse=True, scope="function")
+def mock_azure_credentials_for_helpers(request):
+    """
+    Mock Azure credentials for azure_helper classes only.
+    Skip this for credential utility tests that need to test the actual logic.
+    """
+    # Skip mocking for credential utility tests
+    if "test_azure_credential_utils" in str(request.fspath):
+        yield
+        return
+
+    with patch("helpers.azure_credential_utils.get_azure_credential") as mock_get_cred, \
+         patch("helpers.azure_credential_utils.get_azure_credential_async") as mock_get_cred_async:
+
+        # Create mock credential objects
+        mock_credential = MagicMock()
+        mock_get_cred.return_value = mock_credential
+        mock_get_cred_async.return_value = mock_credential
+
+        yield mock_credential

--- a/src/ContentProcessorAPI/helpers/azure_credential_utils.py
+++ b/src/ContentProcessorAPI/helpers/azure_credential_utils.py
@@ -1,0 +1,35 @@
+import os
+from azure.identity import ManagedIdentityCredential, DefaultAzureCredential
+from azure.identity.aio import ManagedIdentityCredential as AioManagedIdentityCredential, DefaultAzureCredential as AioDefaultAzureCredential
+
+
+async def get_azure_credential_async(client_id=None):
+    """
+    Returns an Azure credential asynchronously based on the application environment.
+    If the environment is 'dev', it uses AioDefaultAzureCredential.
+    Otherwise, it uses AioManagedIdentityCredential.
+    Args:
+        client_id (str, optional): The client ID for the Managed Identity Credential.
+    Returns:
+        Credential object: Either AioDefaultAzureCredential or AioManagedIdentityCredential.
+    """
+    if os.getenv("APP_ENV", "prod").lower() == 'dev':
+        return AioDefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+    else:
+        return AioManagedIdentityCredential(client_id=client_id)
+
+
+def get_azure_credential(client_id=None):
+    """
+    Returns an Azure credential based on the application environment.
+    If the environment is 'dev', it uses DefaultAzureCredential.
+    Otherwise, it uses ManagedIdentityCredential.
+    Args:
+        client_id (str, optional): The client ID for the Managed Identity Credential.
+    Returns:
+        Credential object: Either DefaultAzureCredential or ManagedIdentityCredential.
+    """
+    if os.getenv("APP_ENV", "prod").lower() == 'dev':
+        return DefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+    else:
+        return ManagedIdentityCredential(client_id=client_id)

--- a/src/ContentProcessorAPI/pytest.ini
+++ b/src/ContentProcessorAPI/pytest.ini
@@ -1,0 +1,6 @@
+[tool:pytest]
+addopts = -v --strict-markers --disable-warnings
+python_files = tests.py test_*.py *_tests.py
+testpaths = tests
+markers =
+    asyncio: marks tests as async

--- a/src/ContentProcessorAPI/tests/conftest.py
+++ b/src/ContentProcessorAPI/tests/conftest.py
@@ -1,0 +1,4 @@
+"""
+Test configuration and fixtures for ContentProcessorAPI tests.
+"""
+# Note: pytest_plugins is now defined in the top-level conftest.py

--- a/src/ContentProcessorAPI/tests/helpers/test_azure_credential_utils.py
+++ b/src/ContentProcessorAPI/tests/helpers/test_azure_credential_utils.py
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+# Ensure src/backend is on the Python path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+# Import after path modification (flake8: noqa)
+import helpers.azure_credential_utils as azure_credential_utils  # noqa: E402
+
+
+# Synchronous tests
+
+
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_dev_env(mock_managed_identity_credential, mock_default_azure_credential, mock_getenv):
+    """Test get_azure_credential in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_default_credential = MagicMock()
+    mock_default_azure_credential.return_value = mock_default_credential
+
+    credential = azure_credential_utils.get_azure_credential()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_default_azure_credential.assert_called_once()
+    mock_managed_identity_credential.assert_not_called()
+    assert credential == mock_default_credential
+
+
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_non_dev_env(mock_managed_identity_credential, mock_default_azure_credential, mock_getenv):
+    """Test get_azure_credential in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_managed_credential = MagicMock()
+    mock_managed_identity_credential.return_value = mock_managed_credential
+    credential = azure_credential_utils.get_azure_credential(client_id="test-client-id")
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
+    mock_default_azure_credential.assert_not_called()
+    assert credential == mock_managed_credential
+
+
+# Asynchronous tests
+
+
+@pytest.mark.asyncio
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_dev_env(mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv):
+    """Test get_azure_credential_async in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_aio_default_credential = MagicMock()
+    mock_aio_default_azure_credential.return_value = mock_aio_default_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_default_azure_credential.assert_called_once()
+    mock_aio_managed_identity_credential.assert_not_called()
+    assert credential == mock_aio_default_credential
+
+
+@pytest.mark.asyncio
+@patch("helpers.azure_credential_utils.os.getenv")
+@patch("helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_non_dev_env(mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv):
+    """Test get_azure_credential_async in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_aio_managed_credential = MagicMock()
+    mock_aio_managed_identity_credential.return_value = mock_aio_managed_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async(client_id="test-client-id")
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
+    mock_aio_default_azure_credential.assert_not_called()
+    assert credential == mock_aio_managed_credential


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This pull request introduces significant changes to improve Azure credential handling, streamline environment configuration, and enhance test coverage. The key updates include replacing `DefaultAzureCredential` with a custom utility to dynamically select credentials based on the environment, adding new test configurations and fixtures, and modifying the infrastructure to include an `APP_ENV` variable for environment-specific behavior.

### Azure Credential Management:
* Introduced `get_azure_credential` and `get_azure_credential_async` methods in `helpers/azure_credential_utils.py` to dynamically select `DefaultAzureCredential` for development and `ManagedIdentityCredential` for production.
* Replaced direct usage of `DefaultAzureCredential` with `get_azure_credential` across multiple files, including `application_context.py`, `app_configuration.py`, `azure_openai.py`, `content_understanding.py`, `storage_blob.py`, `pipeline_queue_helper.py`, `remote_module_loader.py`, and `main.py`. [[1]](diffhunk://#diff-67197f11d1b53a16fd99fa161aa184442bc3a367983e0a73ee28c39948589bbfL14-R21) [[2]](diffhunk://#diff-2a7c3307e14b85c3f9eacd90b9cb2a20694ed9b0fae174f959331e784ac97533R1-R15) [[3]](diffhunk://#diff-c3dc5c8ceacc3c455cfcb868deb0a5708ee5cb272358c45552092de9d50c5232L1-R10) [[4]](diffhunk://#diff-d2885efa12627801c8ce014ab2f1705218c734087567e54c3fe9c33eefbb3b6bL10-R24) [[5]](diffhunk://#diff-4f2aa2a64a7fa8211e65707869832a8c41b5814d982d3531b68b46607fcd8feeL6-R18) [[6]](diffhunk://#diff-0444acfe07c93dd13a4ab1d6e8c04406bcb64046c15e6940d64a0aabab06679cL31-R31) [[7]](diffhunk://#diff-ea8659ff943a352ae0569a2b702ee0a7cbd1d351c8b20ac7bc98e14542e99595L30-R30) [[8]](diffhunk://#diff-2a5bd16622fa55f25ee6590432eebc9fcd94051f31a0e5d9eb103afa856c1660L32-R32)

### Environment Configuration:
* Added `APP_ENV` variable with a default value of `prod` in the `infra/main.bicep` file for multiple modules to enable environment-specific configurations. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R810-R813) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R858-R861) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1277-R1280) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1336-R1339)

### Testing Enhancements:
* Created `test_azure_credential_utils.py` to validate the behavior of `get_azure_credential` and `get_azure_credential_async` in both development and production environments.
* Added global test configurations and fixtures in `conftest.py` to mock Azure credentials and streamline test setup. [[1]](diffhunk://#diff-fe0832785e432160d8033f402ea0a099655a547498b4b0fcd6e1a463bd650af9R1-R34) [[2]](diffhunk://#diff-c990d76b0f2e5f4540b2421a2b5d0eab397721c914dfb3b1bac2cf4c2b6f0296R1-R4)
* Updated `pytest.ini` to include strict markers, disable warnings, and define test file patterns.
* Refactored tests in `test_storage_blob.py` to mock `get_azure_credential` instead of `DefaultAzureCredential`.

### Code Cleanup:
* Removed direct imports of `DefaultAzureCredential` where no longer needed and replaced them with the new utility. [[1]](diffhunk://#diff-67197f11d1b53a16fd99fa161aa184442bc3a367983e0a73ee28c39948589bbfL1-R3) [[2]](diffhunk://#diff-c3dc5c8ceacc3c455cfcb868deb0a5708ee5cb272358c45552092de9d50c5232L1-R10) [[3]](diffhunk://#diff-2a5bd16622fa55f25ee6590432eebc9fcd94051f31a0e5d9eb103afa856c1660L8-R8)

These changes collectively improve the flexibility, maintainability, and testability of the codebase while ensuring proper credential handling across different environments.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

