### PR TITLE
fix: prevention of duplicate schema registration

### DIFF
--- a/src/ContentProcessorAPI/samples/schemas/register_schema.ps1
+++ b/src/ContentProcessorAPI/samples/schemas/register_schema.ps1
@@ -12,6 +12,41 @@ if (-not (Test-Path -Path $SchemaInfoJson)) {
     exit 1
 }
 
+# Ensure API endpoint URL is properly formatted
+if ($ApiEndpointUrl -match '/schemavault/?$') {
+    $baseUrl = $ApiEndpointUrl.TrimEnd('/')
+    $getUrl = "$baseUrl/"
+}
+else {
+    $getUrl = "$($ApiEndpointUrl.TrimEnd('/'))/schemavault/"
+}
+
+# Fetch existing schemas
+Write-Output "Fetching existing schemas from: $getUrl"
+try {
+    $httpClient = New-Object System.Net.Http.HttpClient
+    $getResponse = $httpClient.GetAsync($getUrl).Result
+    
+    if ($getResponse.IsSuccessStatusCode) {
+        $existingSchemasJson = $getResponse.Content.ReadAsStringAsync().Result
+        $existingSchemas = $existingSchemasJson | ConvertFrom-Json
+        Write-Output "Successfully fetched $($existingSchemas.Count) existing schema(s)."
+    }
+    else {
+        Write-Warning "Could not fetch existing schemas. HTTP Status: $($getResponse.StatusCode)"
+        $existingSchemas = @()
+    }
+}
+catch {
+    Write-Warning "Error fetching existing schemas: $_. Proceeding with registration..."
+    $existingSchemas = @()
+}
+finally {
+    if ($httpClient) {
+        $httpClient.Dispose()
+    }
+}
+
 # Parse the JSON file and process each schema entry
 $schemaEntries = Get-Content -Path $SchemaInfoJson | ConvertFrom-Json
 
@@ -24,6 +59,9 @@ foreach ($entry in $schemaEntries) {
     $className = $entry.ClassName
     $description = $entry.Description
 
+    Write-Output ""
+    Write-Output "Processing schema: $className"
+
     # Resolve the full path of the schema file
     if (-not [System.IO.Path]::IsPathRooted($schemaFile)) {
         $schemaFile = Join-Path -Path $schemaInfoDirectory -ChildPath $schemaFile
@@ -34,6 +72,23 @@ foreach ($entry in $schemaEntries) {
         Write-Warning "Error: Schema file '$schemaFile' does not exist. Skipping..."
         continue
     }
+
+    # Check if schema with same ClassName already exists
+    $existingSchema = $existingSchemas | Where-Object { $_.ClassName -eq $className } | Select-Object -First 1
+    
+    if ($existingSchema) {
+        Write-Output "✓ Schema '$className' already exists with ID: $($existingSchema.Id)"
+        Write-Output "  Description: $($existingSchema.Description)"
+        
+        # Output to environment variable if running in GitHub Actions or similar
+        if ($env:GITHUB_OUTPUT) {
+            $safeName = $className.ToLower() -replace '[^a-z0-9_]', ''
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "${safeName}_schema_id=$($existingSchema.Id)"
+        }
+        continue
+    }
+
+    Write-Output "Registering new schema '$className'..."
 
     # Extract the filename from the file path
     $filename = [System.IO.Path]::GetFileName($schemaFile)
@@ -85,10 +140,16 @@ foreach ($entry in $schemaEntries) {
             $responseJson = $responseContent | ConvertFrom-Json
             $id = $responseJson.Id
             $desc = $responseJson.Description
-            Write-Output "$desc's Schema Id - $id"
+            Write-Output "✓ Successfully registered: $desc's Schema Id - $id"
+            
+            # Output to environment variable if running in GitHub Actions or similar
+            if ($env:GITHUB_OUTPUT) {
+                $safeName = $className.ToLower() -replace '[^a-z0-9_]', ''
+                Add-Content -Path $env:GITHUB_OUTPUT -Value "${safeName}_schema_id=$id"
+            }
         }
         else {
-            Write-Error "Failed to upload '$schemaFile'. HTTP Status: $httpStatusCode"
+            Write-Error "✗ Failed to upload '$schemaFile'. HTTP Status: $httpStatusCode"
             Write-Error "Error Response: $responseContent"
         }
     }
@@ -96,12 +157,22 @@ foreach ($entry in $schemaEntries) {
         Write-Error "An error occurred while processing '$schemaFile': $_"
     }
     finally {
-        # Ensure the file stream is closed
+        # Ensure resources are disposed
         if ($fileStream) {
             $fileStream.Close()
+            $fileStream.Dispose()
+        }
+        if ($multipartContent) {
+            $multipartContent.Dispose()
+        }
+        if ($httpClient) {
+            $httpClient.Dispose()
         }
     }
 
     # Clean up the temporary JSON file
     Remove-Item -Path $tempJson -Force
 }
+
+Write-Output ""
+Write-Output "Schema registration process completed."


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request improves the schema registration scripts for both PowerShell (`register_schema.ps1`) and Bash (`register_schema.sh`) by adding checks for existing schemas before attempting registration, enhancing output clarity, and ensuring proper resource cleanup. The main goal is to avoid duplicate registrations and provide better feedback during the process.

**Schema existence check and output improvements:**

* Both scripts now fetch existing schemas from the API endpoint before processing new registrations, ensuring that schemas with the same `ClassName` are not registered multiple times.
* If a schema already exists, the scripts output its ID and description, and skip re-registration. The schema ID is also written to the GitHub Actions output file for downstream use. 

**Registration feedback and resource management:**

* Registration success and failure messages are now clearer and more user-friendly, with checkmarks for success and crosses for failure.
* Both scripts output a summary message at the end of the process to indicate completion.
* The PowerShell script improves resource cleanup by disposing of HTTP and file stream objects after use.

**User experience enhancements:**

* Each schema being processed is now announced in the output, making it easier to track progress during execution.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

