### PR TITLE
chore: commented the azure location from vs code web .env

### DIFF
--- a/infra/vscode_web/.env
+++ b/infra/vscode_web/.env
@@ -1,6 +1,6 @@
 AZURE_EXISTING_AGENT_ID="<%= agentId %>"
 AZURE_ENV_NAME="<%= playgroundName %>"
-AZURE_LOCATION="<%= location %>"
+# AZURE_LOCATION="<%= location %>"
 AZURE_SUBSCRIPTION_ID="<%= subscriptionId %>"
 AZURE_EXISTING_AIPROJECT_ENDPOINT="<%= endpoint %>"
 AZURE_EXISTING_AIPROJECT_RESOURCE_ID="<%= projectResourceId %>"


### PR DESCRIPTION
## Purpose
This pull request makes a small change to the `infra/vscode_web/.env` file, commenting out the `AZURE_LOCATION` environment variable. This prevents the value from being set or used in the current environment configuration.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

