### PR TITLE
perf: Refactor imports and clean up unused variables across multiple components

### DIFF
--- a/src/ContentProcessorWeb/src/Components/Header/Header.tsx
+++ b/src/ContentProcessorWeb/src/Components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useHeaderHooks, Header } from "../../Hooks/useHeaderHooks.tsx";
+import { Header } from "../../Hooks/useHeaderHooks.tsx";
 import {
   TabList,
   Tab,

--- a/src/ContentProcessorWeb/src/Components/JSONEditor/JSONEditor.tsx
+++ b/src/ContentProcessorWeb/src/Components/JSONEditor/JSONEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { JsonEditor, JsonEditorProps, githubDarkTheme } from 'json-edit-react'
+import { JsonEditor } from 'json-edit-react'
 import './JSONEditor.styles.scss'
 
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';

--- a/src/ContentProcessorWeb/src/Components/UploadContent/UploadFilesModal.tsx
+++ b/src/ContentProcessorWeb/src/Components/UploadContent/UploadFilesModal.tsx
@@ -209,7 +209,7 @@ const UploadFilesModal: React.FC<UploadFilesModalProps> = ({ open, onClose }) =>
     setUploading(false);
     setFileErrors({})
     setUploadCompleted(false);
-  }
+  };
   const isSchemaSelectedOptionEmpty = !store.schemaSelectedOption || Object.keys(store.schemaSelectedOption).length === 0;
   const onCloseHandler = () => {
     resetState();

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/Components/ProcessQueueGrid/ProcessQueueGrid.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/Components/ProcessQueueGrid/ProcessQueueGrid.tsx
@@ -3,7 +3,7 @@ import { FixedSizeList as List } from "react-window";
 import { DocumentQueueAdd20Regular, DocumentPdfRegular, ImageRegular } from "@fluentui/react-icons";
 import { Tooltip } from "@fluentui/react-components";
 import {
-     useScrollbarWidth, useFluent, TableBody, TableCell, TableRow, Table,
+    TableBody, TableCell, TableRow, Table,
     TableHeader, TableHeaderCell, TableCellLayout, createTableColumn, useTableFeatures,
     useTableSelection, useTableSort, TableColumnId, 
     TableRowId
@@ -79,8 +79,6 @@ const ProcessQueueGrid: React.FC<GridComponentProps> = () => {
     }), shallowEqual
     );
 
-    const { targetDocument } = useFluent();
-    
     const [sortState, setSortState] = useState<{
         sortDirection: "ascending" | "descending";
         sortColumn: TableColumnId | undefined;
@@ -166,9 +164,6 @@ const ProcessQueueGrid: React.FC<GridComponentProps> = () => {
         getRows,
         sort: { getSortDirection, toggleColumnSort, sort },
         selection: {
-            allRowsSelected,
-            someRowsSelected,
-            toggleAllRows,
             toggleRow,
             isRowSelected,
         },

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/Components/ProcessSteps/ProcessSteps.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/Components/ProcessSteps/ProcessSteps.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { Accordion, AccordionItem, AccordionHeader, AccordionPanel } from "@fluentui/react-components";
 import { useSelector, shallowEqual } from 'react-redux';
 import { RootState } from '../../../../store/index.ts';

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelRight.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelRight.tsx
@@ -4,7 +4,6 @@ import DocumentViewer from '../../Components/DocumentViewer/DocumentViewer.tsx'
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { AppDispatch, RootState } from '../../store';
 import { fetchContentFileData } from '../../store/slices/rightPanelSlice'
-import { updatePanelCollapse } from "../../store/slices/defaultPageSlice.ts";
 import { bundleIcon, ChevronDoubleLeft20Filled, ChevronDoubleLeft20Regular } from "@fluentui/react-icons";
 import { Button } from "@fluentui/react-components";
 const ChevronDoubleLeft = bundleIcon(ChevronDoubleLeft20Regular, ChevronDoubleLeft20Filled);

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/index.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/index.tsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { AppDispatch, RootState } from '../../store/index.ts';
 import { updatePanelCollapse } from "../../store/slices/defaultPageSlice.ts";
 
-import { makeStyles, Button } from "@fluentui/react-components";
+import { Button } from "@fluentui/react-components";
 
 const Page: React.FC = () => {
 

--- a/src/ContentProcessorWeb/src/Pages/HomePage.tsx
+++ b/src/ContentProcessorWeb/src/Pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 const Page: React.FC = () => {
   return (

--- a/src/ContentProcessorWeb/src/Services/httpUtility.ts
+++ b/src/ContentProcessorWeb/src/Services/httpUtility.ts
@@ -81,7 +81,6 @@ const fetchWithAuth = async <T>(
     if (error?.status !== undefined) {
       throw error;
     }
-    const isNetworkError = error instanceof TypeError && error.message === 'Failed to fetch';
     const isOffline = !navigator.onLine; //isNetworkError ||
 
     const message = isOffline

--- a/src/ContentProcessorWeb/src/msal-auth/AuthWrapper.tsx
+++ b/src/ContentProcessorWeb/src/msal-auth/AuthWrapper.tsx
@@ -1,8 +1,5 @@
 
 import React, { useEffect } from "react";
-import { msalInstance } from "./msalInstance";
-import { loginRequest } from "./msaConfig";
-import { useMsal, useIsAuthenticated } from "@azure/msal-react";
 import { InteractionStatus } from "@azure/msal-browser";
 
 import useAuth from './useAuth';

--- a/src/ContentProcessorWeb/src/store/slices/centerPanelSlice.ts
+++ b/src/ContentProcessorWeb/src/store/slices/centerPanelSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 import httpUtility, { handleApiThunk } from '../../Services/httpUtility';
 import { toast } from "react-toastify";

--- a/src/ContentProcessorWeb/src/store/slices/defaultPageSlice.ts
+++ b/src/ContentProcessorWeb/src/store/slices/defaultPageSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
 interface defaultPageState {
     isLeftPanelCollapse: boolean;

--- a/src/ContentProcessorWeb/src/store/slices/rightPanelSlice.ts
+++ b/src/ContentProcessorWeb/src/store/slices/rightPanelSlice.ts
@@ -2,7 +2,6 @@ import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 
 import httpUtility from '../../Services/httpUtility';
 
-import { toast } from "react-toastify";
 interface T {
     headers: any,
     blobURL: string,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request primarily refactors import statements across multiple files in the codebase to remove unused imports and streamline dependencies. It also includes minor code cleanups and state reset improvements. These changes help reduce bundle size, improve code readability, and prevent potential issues caused by unused code.

### Import statement cleanup and optimization

* Removed unused imports such as `PayloadAction`, `makeStyles`, `useHeaderHooks`, `githubDarkTheme`, and others from various files including `centerPanelSlice.ts`, `defaultPageSlice.ts`, `rightPanelSlice.ts`, `Header.tsx`, `JSONEditor.tsx`, and `index.tsx`. [[1]](diffhunk://#diff-b31803a1b99b50b8b4139bbefd9aef75989cabb08d326d653e4c24952b2feea8L1-R1) [[2]](diffhunk://#diff-41bc01ff4cda8b4f7ab2a794adcf97a5964228d8bd0d82273b207fb4c256443eL1-R1) [[3]](diffhunk://#diff-361c238bd91f19649fcac1fa52247e1117a059d54f4b7e3a373582b4f37593feL5) [[4]](diffhunk://#diff-df64650de0490e24db71ed8b60b139a07ac3e067affa6523cb3b2dfccf5a910aL3-R3) [[5]](diffhunk://#diff-1efd415b15986339474408fd909465e92b7c7bb7b1f8148e3d14864ec85353eaL2-R2) [[6]](diffhunk://#diff-1d0d91c767497e01778df2ee536ebcf57b10024cbcd2c770bfebebc703c623e0L11-R11)
* Cleaned up imports in authentication-related files, removing unnecessary MSAL imports in `AuthWrapper.tsx`.
* Removed unused React hooks such as `useCallback` and `useState` from `ProcessSteps.tsx` and `HomePage.tsx`. [[1]](diffhunk://#diff-869dd55b67d24b8e59e863fa5e4b94da54e754332374e8723fd217dc67ec50c6L1-R1) [[2]](diffhunk://#diff-a3be1b07cf35c9908906753d3218b56c81077af744d6dc1b493d9aeebbed614eL1-R1)
* Removed unnecessary imports from `PanelRight.tsx`.

### Codebase simplification

* Removed unused utility functions and variables, such as `useScrollbarWidth`, `useFluent`, and `targetDocument` from `ProcessQueueGrid.tsx`. [[1]](diffhunk://#diff-7a5d3a043adff4db35c234ca00c097170968d7e2cf648b13ed904658c6e9f925L6-R6) [[2]](diffhunk://#diff-7a5d3a043adff4db35c234ca00c097170968d7e2cf648b13ed904658c6e9f925L82-L83)
* Cleaned up table selection logic by removing unused properties in `ProcessQueueGrid.tsx`.
* Removed unused error handling logic in `httpUtility.ts`.

### Minor functional improvements

* Improved state reset logic in `UploadFilesModal.tsx` by properly terminating the function with a semicolon.

## 19 findings:
<img width="1861" height="901" alt="image" src="https://github.com/user-attachments/assets/46f80af0-d8a8-4dd5-b897-b8af37c79c38" />


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

