### PR TITLE
fix: fix parameters in deployment templates to match bicep file

### DIFF
--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -10,18 +10,27 @@ By default this template will use the environment name as the prefix to prevent 
 | Name                                   | Type    | Example Value               | Purpose                                                                               |
 | -------------------------------------- | ------- | --------------------------- | ------------------------------------------------------------------------------------- |
 | `AZURE_ENV_NAME`                       | string  | `cps`                     | Sets the environment name prefix for all Azure resources.                             |
-| `AZURE_ENV_SECONDARY_LOCATION`         | string  | `eastus2`                 | Specifies a secondary Azure region.                                                   |
-| `AZURE_ENV_CU_LOCATION`                | string  | `WestUS`                  | Sets the location for the Azure Content Understanding service.                        |
+| `AZURE_LOCATION`                       | string  | `eastus2`                 | Sets the primary Azure region for resource deployment (allowed values: `australiaeast`, `centralus`, `eastasia`, `eastus2`, `japaneast`, `northeurope`, `southeastasia`, `uksouth`). |
+| `AZURE_ENV_AI_DEPLOYMENTS_LOCATION`    | string  | `eastus2`                 | Sets the location for the Azure AI Services deployment (allowed values: `australiaeast`, `eastus`, `eastus2`, `francecentral`, `japaneast`, `swedencentral`, `uksouth`, `westus`, `westus3`). |
+| `AZURE_ENV_CU_LOCATION`               | string  | `WestUS`                  | Sets the location for the Azure Content Understanding service (allowed values: `WestUS`, `SwedenCentral`, `AustraliaEast`). |
 | `AZURE_ENV_MODEL_DEPLOYMENT_TYPE`      | string  | `GlobalStandard`          | Defines the model deployment type (allowed values: `Standard`, `GlobalStandard`).     |
-| `AZURE_ENV_MODEL_NAME`                 | string  | `gpt-4o`                  | Specifies the GPT model name (allowed values: `gpt-4o`).       
-| `AZURE_ENV_MODEL_VERSION`                 | string  | `2024-08-06`                  | Specifies the GPT model version (allowed values: `2024-08-06`).                       |
-| `AZURE_ENV_MODEL_CAPACITY`             | integer | `30`                        | Sets the model capacity (choose based on your subscription's available GPT capacity). |
-| `AZURE_ENV_IMAGETAG`                      | boolean | `latest`                     | Set the Image tag Like (allowed values: latest, dev, hotfix)                       |
-| `AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT` | string  | `cpscontainerreg.azurecr.io` | Sets the Azure Container Registry name (allowed value: `cpscontainerreg.azurecr.io`) |            |
-| `AZURE_ENV_CONTAINER_IMAGE_TAG`        | string  | `latest`                    | Sets the container image tag (e.g., `latest`, `dev`, `hotfix`).            |
-| `AZURE_LOCATION`                       | string  | `eastus`                    | Sets the primary Azure region for resource deployment.                                |
-| `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID` | string  | Guide to get your [Existing Workspace ID](/docs/re-use-log-analytics.md) | Reuses an existing Log Analytics Workspace instead of provisioning a new one.         |
-| `AZURE_EXISTING_AI_PROJECT_RESOURCE_ID`    | string  | `<Existing AI Project resource Id>`            | Reuses an existing AIFoundry and AIFoundryProject instead of creating a new one.  |
+| `AZURE_ENV_MODEL_NAME`                 | string  | `gpt-4o`                  | Specifies the GPT model name (allowed values: `gpt-4o`).              |
+| `AZURE_ENV_MODEL_VERSION`              | string  | `2024-08-06`              | Specifies the GPT model version (allowed values: `2024-08-06`).                       |
+| `AZURE_ENV_MODEL_CAPACITY`             | integer | `30`                      | Sets the model capacity (choose based on your subscription's available GPT capacity). |
+| `AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT` | string | `cpscontainerreg.azurecr.io` | Sets the Azure Container Registry endpoint (allowed value: `cpscontainerreg.azurecr.io`). |
+| `AZURE_ENV_CONTAINER_IMAGE_TAG`        | string  | `latest`                  | Sets the container image tag (e.g., `latest`, `dev`, `hotfix`).                       |
+| `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID` | string  | Guide to get your [Existing Workspace ID](/docs/re-use-log-analytics.md) | Reuses an existing Log Analytics Workspace instead of provisioning a new one. |
+| `AZURE_ENV_FOUNDRY_PROJECT_ID`         | string  | `<Existing AI Project resource Id>` | Reuses an existing AI Foundry and AI Foundry Project instead of creating a new one. |
+
+### WAF Deployment Parameters
+
+The following parameters are only used when deploying with WAF-aligned configuration (`main.waf.parameters.json`):
+
+| Name                                   | Type    | Example Value               | Purpose                                                                               |
+| -------------------------------------- | ------- | --------------------------- | ------------------------------------------------------------------------------------- |
+| `AZURE_ENV_VM_SIZE`                    | string  | `Standard_DS2_v2`          | Sets the size of the Jumpbox Virtual Machine.                                         |
+| `AZURE_ENV_VM_ADMIN_USERNAME`          | string  | `JumpboxAdminUser`          | Sets the admin username for the Jumpbox Virtual Machine.                              |
+| `AZURE_ENV_VM_ADMIN_PASSWORD`          | string  | *(secure)*                  | Sets the admin password for the Jumpbox Virtual Machine.                              |
 
 ## How to Set a Parameter
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.40.2.10011",
-      "templateHash": "4821257159531769907"
+      "version": "0.41.2.15936",
+      "templateHash": "3702628187124943368"
     },
     "name": "Content Processing Solution Accelerator",
     "description": "Bicep template to deploy the Content Processing Solution Accelerator with AVM compliance."
@@ -350,8 +350,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "637986880127430337"
+              "version": "0.41.2.15936",
+              "templateHash": "4055670269816744382"
             }
           },
           "definitions": {
@@ -19227,8 +19227,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "3741201002953968110"
+              "version": "0.41.2.15936",
+              "templateHash": "6350282028214740152"
             }
           },
           "parameters": {
@@ -23233,8 +23233,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "10844547551448610415"
+              "version": "0.41.2.15936",
+              "templateHash": "13929816981891754138"
             }
           },
           "parameters": {
@@ -23825,8 +23825,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "7885429842089695683"
+              "version": "0.41.2.15936",
+              "templateHash": "17694195801715707119"
             },
             "name": "Container Registry Module"
           },
@@ -35290,8 +35290,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "7557665774149769517"
+              "version": "0.41.2.15936",
+              "templateHash": "11676375352983709807"
             },
             "name": "Cognitive Services",
             "description": "This module deploys a Cognitive Service."
@@ -36540,8 +36540,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "6588447351857766372"
+                      "version": "0.41.2.15936",
+                      "templateHash": "8716336912243881623"
                     }
                   },
                   "definitions": {
@@ -38349,8 +38349,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.40.2.10011",
-                              "templateHash": "14939823368517410024"
+                              "version": "0.41.2.15936",
+                              "templateHash": "10989408486030617267"
                             }
                           },
                           "definitions": {
@@ -38503,8 +38503,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.40.2.10011",
-                              "templateHash": "13151306134286549002"
+                              "version": "0.41.2.15936",
+                              "templateHash": "7933643033523871028"
                             }
                           },
                           "definitions": {
@@ -38721,8 +38721,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "6588447351857766372"
+                      "version": "0.41.2.15936",
+                      "templateHash": "8716336912243881623"
                     }
                   },
                   "definitions": {
@@ -40530,8 +40530,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.40.2.10011",
-                              "templateHash": "14939823368517410024"
+                              "version": "0.41.2.15936",
+                              "templateHash": "10989408486030617267"
                             }
                           },
                           "definitions": {
@@ -40684,8 +40684,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.40.2.10011",
-                              "templateHash": "13151306134286549002"
+                              "version": "0.41.2.15936",
+                              "templateHash": "7933643033523871028"
                             }
                           },
                           "definitions": {
@@ -40925,9 +40925,9 @@
       "dependsOn": [
         "avmContainerApp",
         "avmManagedIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').contentUnderstanding)]",
         "logAnalyticsWorkspace",
         "virtualNetwork"

--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -41,10 +41,13 @@
     "enableScalability": {
       "value": true
     },
-    "virtualMachineAdminUsername": {
+    "vmSize": {
+      "value": "${AZURE_ENV_VM_SIZE}"
+    },
+    "vmAdminUsername": {
       "value": "${AZURE_ENV_VM_ADMIN_USERNAME}"
     },
-    "virtualMachineAdminPassword": {
+    "vmAdminPassword": {
       "value": "${AZURE_ENV_VM_ADMIN_PASSWORD}"
     },
     "publicContainerImageEndpoint": {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates documentation and infrastructure templates to improve parameter clarity, support WAF-aligned deployments, and ensure compatibility with the latest Bicep tooling. The most significant changes are the addition of new parameters for WAF deployments, updates to parameter naming and allowed values, and a Bicep version upgrade across infrastructure files.

**Documentation and Parameter Updates:**

* Added new documentation for WAF deployment parameters in `docs/CustomizingAzdParameters.md`, including `AZURE_ENV_VM_SIZE`, `AZURE_ENV_VM_ADMIN_USERNAME`, and `AZURE_ENV_VM_ADMIN_PASSWORD`. Also clarified and updated existing parameter descriptions and allowed values, and renamed or replaced some parameters for consistency.
* Updated WAF parameter names in `infra/main.waf.parameters.json` to match new documentation and environment variable naming conventions (`vmSize`, `vmAdminUsername`, `vmAdminPassword`).

**Infrastructure and Tooling Updates:**

* Upgraded Bicep generator version from `0.40.2.10011` to `0.41.2.15936` in multiple sections of `infra/main.json`, resulting in new template hashes throughout the file [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L353-R354) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19230-R19231) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L23236-R23237) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L23828-R23829) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L35293-R35294) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L36543-R36544) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L38352-R38353) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L38506-R38507) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L38724-R38725) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L40533-R40534) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L40687-R40688).
* Corrected resource dependency ordering in `infra/main.json` for private DNS zones to ensure proper deployment sequencing.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

