### PR TITLE
fix: standardize imageTag env variable from AZURE_ENV_IMAGETAG to AZURE_ENV_IMAGE_TAG

### DIFF
--- a/.github/workflows/job-deploy-linux.yml
+++ b/.github/workflows/job-deploy-linux.yml
@@ -242,7 +242,7 @@ jobs:
           azd env set AZURE_ENV_AI_SERVICE_LOCATION="$AZURE_ENV_OPENAI_LOCATION"
           azd env set AZURE_LOCATION="$AZURE_LOCATION"
           azd env set AZURE_RESOURCE_GROUP="$RESOURCE_GROUP_NAME"
-          azd env set AZURE_ENV_IMAGETAG="$IMAGE_TAG"
+          azd env set AZURE_ENV_IMAGE_TAG="$IMAGE_TAG"
 
           if [[ "$BUILD_DOCKER_IMAGE" == "true" ]]; then
             ACR_NAME=$(echo "${{ secrets.ACR_TEST_LOGIN_SERVER }}")

--- a/.github/workflows/job-deploy-windows.yml
+++ b/.github/workflows/job-deploy-windows.yml
@@ -239,7 +239,7 @@ jobs:
           azd env set AZURE_ENV_AI_SERVICE_LOCATION="$env:AZURE_ENV_OPENAI_LOCATION"
           azd env set AZURE_LOCATION="$env:AZURE_LOCATION"
           azd env set AZURE_RESOURCE_GROUP="$env:RESOURCE_GROUP_NAME"
-          azd env set AZURE_ENV_IMAGETAG="$env:IMAGE_TAG"
+          azd env set AZURE_ENV_IMAGE_TAG="$env:IMAGE_TAG"
 
           # Set ACR name only when building Docker image
           if ($env:BUILD_DOCKER_IMAGE -eq "true") {

--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -18,7 +18,7 @@ By default this template will use the environment name as the prefix to prevent 
 | `AZURE_ENV_GPT_MODEL_VERSION`              | string  | `2025-11-13`              | Specifies the GPT model version.                                                      |
 | `AZURE_ENV_GPT_MODEL_CAPACITY`             | integer | `300`                       | Sets the model capacity (minimum 1). Default: 300. Optimal: 500 for multi-document claim processing. |
 | `AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT` | string  | `cpscontainerreg.azurecr.io` | Sets the public container image endpoint for pulling pre-built images.                |
-| `AZURE_ENV_IMAGETAG`        | string  | `latest_v2`                 | Sets the container image tag (e.g., `latest_v2`, `dev`, `demo`, `hotfix`).                    |
+| `AZURE_ENV_IMAGE_TAG`        | string  | `latest_v2`                 | Sets the container image tag (e.g., `latest_v2`, `dev`, `demo`, `hotfix`).                    |
 | `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID` | string  | Guide to get your [Existing Workspace Resource ID](/docs/re-use-log-analytics.md) | Reuses an existing Log Analytics Workspace instead of provisioning a new one.         |
 | `AZURE_EXISTING_AIPROJECT_RESOURCE_ID`         | string  | Guide to get your [Existing AI Project Resource ID](/docs/re-use-foundry-project.md) | Reuses an existing AI Foundry and AI Foundry Project instead of creating a new one.   |
 | `AZURE_ENV_VM_SIZE` | string | `Standard_D2s_v5` | Overrides the jumpbox VM size (private networking only). Default: `Standard_D2s_v5`. |

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -36,7 +36,7 @@
       "value": "${AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT}"
     },
     "imageTag": {
-      "value": "${AZURE_ENV_IMAGETAG=latest_v2}"
+      "value": "${AZURE_ENV_IMAGE_TAG=latest_v2}"
     }
   }
 }

--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -54,7 +54,7 @@
       "value": "${AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT}"
     },
     "imageTag": {
-      "value": "${AZURE_ENV_IMAGETAG=latest_v2}"
+      "value": "${AZURE_ENV_IMAGE_TAG=latest_v2}"
     }
   }
 }

--- a/infra/scripts/docker-build.ps1
+++ b/infra/scripts/docker-build.ps1
@@ -20,7 +20,7 @@ function Build-And-Push-Image {
         [string]$CONTAINER_APP_NAME
     )
 
-    $IMAGE_URI = "$ACR_NAME.azurecr.io/$($IMAGE_NAME):$AZURE_ENV_IMAGETAG"
+    $IMAGE_URI = "$ACR_NAME.azurecr.io/$($IMAGE_NAME):$AZURE_ENV_IMAGE_TAG"
 
     Write-Host "Building Docker image: $IMAGE_URI"
     docker build $BUILD_PATH --no-cache -t $IMAGE_URI
@@ -103,7 +103,7 @@ $ENV_NAME = Get-AzdEnvValueOrDefault -KeyName "AZURE_ENV_NAME" -Required $true
 $CONTAINER_APP_USER_IDENTITY_ID = Get-AzdEnvValueOrDefault -KeyName "CONTAINER_APP_USER_IDENTITY_ID" -Required $true
 $AZURE_RESOURCE_GROUP = Get-AzdEnvValueOrDefault -KeyName "AZURE_RESOURCE_GROUP" -Required $true
 $CONTAINER_APP_USER_PRINCIPAL_ID = Get-AzdEnvValueOrDefault -KeyName "CONTAINER_APP_USER_PRINCIPAL_ID" -Required $true
-$AZURE_ENV_IMAGETAG = Get-AzdEnvValueOrDefault -KeyName "AZURE_ENV_IMAGETAG" -DefaultValue "latest_v2"
+$AZURE_ENV_IMAGE_TAG = Get-AzdEnvValueOrDefault -KeyName "AZURE_ENV_IMAGE_TAG" -DefaultValue "latest_v2"
 $CONTAINER_WEB_APP_NAME=Get-AzdEnvValueOrDefault -KeyName "CONTAINER_WEB_APP_NAME" -Required $true
 $CONTAINER_API_APP_NAME=Get-AzdEnvValueOrDefault -KeyName "CONTAINER_API_APP_NAME" -Required $true
 $CONTAINER_APP_NAME=Get-AzdEnvValueOrDefault -KeyName "CONTAINER_APP_NAME" -Required $true
@@ -116,7 +116,7 @@ Write-Host "Using the following parameters:"
 Write-Host "AZURE_SUBSCRIPTION_ID = $AZURE_SUBSCRIPTION_ID"
 Write-Host "ENV_NAME = $ENV_NAME"
 Write-Host "AZURE_RESOURCE_GROUP = $AZURE_RESOURCE_GROUP"
-Write-Host "AZURE_ENV_IMAGETAG = $AZURE_ENV_IMAGETAG"
+Write-Host "AZURE_ENV_IMAGE_TAG = $AZURE_ENV_IMAGE_TAG"
 
 Ensure-AzLogin
 

--- a/infra/scripts/docker-build.sh
+++ b/infra/scripts/docker-build.sh
@@ -36,7 +36,7 @@ ENV_NAME=$(get_azd_env_value_or_default "AZURE_ENV_NAME" "" true)
 CONTAINER_APP_USER_IDENTITY_ID=$(get_azd_env_value_or_default "CONTAINER_APP_USER_IDENTITY_ID" "" true)
 AZURE_RESOURCE_GROUP=$(get_azd_env_value_or_default "AZURE_RESOURCE_GROUP" "" true)
 CONTAINER_APP_USER_PRINCIPAL_ID=$(get_azd_env_value_or_default "CONTAINER_APP_USER_PRINCIPAL_ID" "" true)
-AZURE_ENV_IMAGETAG=$(get_azd_env_value_or_default "AZURE_ENV_IMAGETAG" "latest_v2" false)
+AZURE_ENV_IMAGE_TAG=$(get_azd_env_value_or_default "AZURE_ENV_IMAGE_TAG" "latest_v2" false)
 CONTAINER_WEB_APP_NAME=$(get_azd_env_value_or_default "CONTAINER_WEB_APP_NAME" "" true)
 CONTAINER_API_APP_NAME=$(get_azd_env_value_or_default "CONTAINER_API_APP_NAME" "" true)
 CONTAINER_APP_NAME=$(get_azd_env_value_or_default "CONTAINER_APP_NAME" "" true)
@@ -48,7 +48,7 @@ echo "Using the following parameters:"
 echo "AZURE_SUBSCRIPTION_ID = $AZURE_SUBSCRIPTION_ID"
 echo "ENV_NAME = $ENV_NAME"
 echo "AZURE_RESOURCE_GROUP = $AZURE_RESOURCE_GROUP"
-echo "AZURE_ENV_IMAGETAG = $AZURE_ENV_IMAGETAG"
+echo "AZURE_ENV_IMAGE_TAG = $AZURE_ENV_IMAGE_TAG"
 
 # Ensure Azure login
 echo "Checking Azure login status..."
@@ -85,7 +85,7 @@ build_and_push_image() {
     BUILD_PATH="$2"
     CONTAINER_APP="$3"
 
-    IMAGE_URI="$ACR_NAME.azurecr.io/$IMAGE_NAME:$AZURE_ENV_IMAGETAG"
+    IMAGE_URI="$ACR_NAME.azurecr.io/$IMAGE_NAME:$AZURE_ENV_IMAGE_TAG"
     echo "Building image: $IMAGE_URI"
     docker build "$BUILD_PATH" --no-cache -t "$IMAGE_URI"
     


### PR DESCRIPTION
## Purpose

Standardize the \imageTag\ AZD environment variable name from \AZURE_ENV_IMAGETAG\ to \AZURE_ENV_IMAGE_TAG\ to comply with the Bicep naming standards convention (underscore-separated words).

## Changes

Renamed \AZURE_ENV_IMAGETAG\ → \AZURE_ENV_IMAGE_TAG\ in **7 files**:

| File | Change |
|---|---|
| \infra/main.parameters.json\ | Env variable name in parameter value |
| \infra/main.waf.parameters.json\ | Env variable name in parameter value |
| \infra/scripts/docker-build.sh\ | Variable read, echo, and usage |
| \infra/scripts/docker-build.ps1\ | Variable read, echo, and usage |
| \.github/workflows/job-deploy-linux.yml\ | \zd env set\ command |
| \.github/workflows/job-deploy-windows.yml\ | \zd env set\ command |
| \docs/CustomizingAzdParameters.md\ | Documentation table entry |

**Default value remains \latest_v2\** — only the env variable name is corrected.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

> **Note:** Users who previously set \AZURE_ENV_IMAGETAG\ in their AZD environment will need to update to \AZURE_ENV_IMAGE_TAG\.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.
