### PR TITLE
fix: update ai summary and gap analysis once refresh is clicked

### DIFF
--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelCenter.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelCenter.tsx
@@ -149,6 +149,7 @@ const PanelCenter: React.FC<PanelCenterProps> = ({ togglePanel }) => {
     claimDetails: state.centerPanel.claimDetails,
     claimDetailsLoader: state.centerPanel.claimDetailsLoader,
     claimCommentSaving: state.centerPanel.claimCommentSaving,
+    refreshTrigger: state.leftPanel.refreshTrigger,
   }), shallowEqual
   );
 
@@ -186,7 +187,7 @@ const PanelCenter: React.FC<PanelCenterProps> = ({ togglePanel }) => {
     if (store.selectionType === 'document' && (store.activeProcessId != null || store.activeProcessId !== '') && !status.includes(store.selectedItem.status) && store.selectedItem?.process_id === store.activeProcessId) {
       fetchContent();
     }
-  }, [store.activeProcessId, store.selectedItem, store.selectionType])
+  }, [store.activeProcessId, store.selectedItem, store.selectionType, store.refreshTrigger])
 
   // Fetch claim details when a claim is selected
   useEffect(() => {
@@ -194,7 +195,7 @@ const PanelCenter: React.FC<PanelCenterProps> = ({ togglePanel }) => {
       setClaimComment('');
       dispatch(fetchClaimDetails({ claimId: store.selectedClaim.id }));
     }
-  }, [store.selectionType, store.selectedClaim?.id, dispatch])
+  }, [store.selectionType, store.selectedClaim?.id, dispatch, store.refreshTrigger])
 
   // Sync claim comment with API response
   useEffect(() => {

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelLeft.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelLeft.tsx
@@ -13,7 +13,7 @@ import { ArrowClockwiseRegular, ArrowUploadRegular, ChevronDoubleLeft20Regular, 
 import { toast } from "react-toastify";
 
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
-import { fetchSchemaData, fetchSchemasetData, fetchContentTableData, setRefreshGrid, fetchSwaggerData } from '../../store/slices/leftPanelSlice';
+import { fetchSchemaData, fetchSchemasetData, fetchContentTableData, setRefreshGrid, fetchSwaggerData, incrementRefreshTrigger } from '../../store/slices/leftPanelSlice';
 import { AppDispatch, RootState } from '../../store';
 import { startLoader, stopLoader } from "../../store/slices/loaderSlice";
 
@@ -80,6 +80,7 @@ const PanelLeft: React.FC<PanelLeftProps> = ({ togglePanel }) => {
     } finally {
       dispatch(stopLoader("1"));
       dispatch(setRefreshGrid(false));
+      dispatch(incrementRefreshTrigger());
     }
   }
 

--- a/src/ContentProcessorWeb/src/store/slices/leftPanelSlice.ts
+++ b/src/ContentProcessorWeb/src/store/slices/leftPanelSlice.ts
@@ -27,6 +27,7 @@ export interface LeftPanelState {
     deleteClaimsLoader: string[];
     isGridRefresh: boolean;
     swaggerJSON: Record<string, unknown> | null;
+    refreshTrigger: number;
 }
 
 interface GridData {
@@ -245,6 +246,7 @@ const initialState: LeftPanelState = {
     deleteFilesLoader: [],
     deleteClaimsLoader: [],
     swaggerJSON: null,
+    refreshTrigger: 0,
 };
 
 const leftPanelSlice = createSlice({
@@ -267,6 +269,9 @@ const leftPanelSlice = createSlice({
         },
         setRefreshGrid: (state, action: PayloadAction<boolean>) => {
             state.isGridRefresh = action.payload;
+        },
+        incrementRefreshTrigger: (state) => {
+            state.refreshTrigger += 1;
         },
     },
     extraReducers: (builder) => {
@@ -406,5 +411,5 @@ const leftPanelSlice = createSlice({
     },
 });
 
-export const { setSchemaSelectedOption, setSelectedGridRow, setSelectedClaim, setRefreshGrid } = leftPanelSlice.actions;
+export const { setSchemaSelectedOption, setSelectedGridRow, setSelectedClaim, setRefreshGrid, incrementRefreshTrigger } = leftPanelSlice.actions;
 export default leftPanelSlice.reducer;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This pull request introduces a mechanism to trigger refreshes across panels by adding a `refreshTrigger` counter to the Redux state and updating relevant components to react to its changes. The main goal is to ensure that when data is refreshed in the left panel, the center panel also re-fetches its data as needed.

**State management enhancements:**

* Added a `refreshTrigger` numeric field to the `LeftPanelState` interface and initialized it in the Redux slice state (`leftPanelSlice.ts`). [[1]](diffhunk://#diff-9b395d212aef237a1da9148a1fe900e3ca07a66663ae20cbd9164f040f2575e1R30) [[2]](diffhunk://#diff-9b395d212aef237a1da9148a1fe900e3ca07a66663ae20cbd9164f040f2575e1R249)
* Implemented the `incrementRefreshTrigger` action in the Redux slice to increment the `refreshTrigger` counter, and exported it for use in components. [[1]](diffhunk://#diff-9b395d212aef237a1da9148a1fe900e3ca07a66663ae20cbd9164f040f2575e1R273-R275) [[2]](diffhunk://#diff-9b395d212aef237a1da9148a1fe900e3ca07a66663ae20cbd9164f040f2575e1L409-R414)

**Component updates for refresh handling:**

* In `PanelLeft`, after refreshing the grid, dispatches `incrementRefreshTrigger()` to signal that a refresh has occurred (`PanelLeft.tsx`). [[1]](diffhunk://#diff-7d1b949747b90e617d6623b46cf8e8f444b7e32d2d6e7ad06d5ac3e789f3b3b1L16-R16) [[2]](diffhunk://#diff-7d1b949747b90e617d6623b46cf8e8f444b7e32d2d6e7ad06d5ac3e789f3b3b1R83)
* In `PanelCenter`, subscribes to `refreshTrigger` from the Redux store and adds it as a dependency to the relevant `useEffect` hooks, ensuring that content and claim details are re-fetched when a refresh is triggered (`PanelCenter.tsx`). [[1]](diffhunk://#diff-3d8f0969f69afcc3f9f7b00d51f438673f2c65f243938d40c52a0c20dffbe080R152) [[2]](diffhunk://#diff-3d8f0969f69afcc3f9f7b00d51f438673f2c65f243938d40c52a0c20dffbe080L189-R198)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

