### PR TITLE
chore: remove unused axios dependency from ContentProcessorWeb

### DIFF
--- a/src/ContentProcessorWeb/.github/instructions/code-quality.instructions.md
+++ b/src/ContentProcessorWeb/.github/instructions/code-quality.instructions.md
@@ -104,7 +104,7 @@ You are performing a systematic code-quality pass on a TypeScript/React codebase
 
 - **Group imports** in this order, separated by blank lines:
   1. React / React DOM
-  2. Third-party libraries (`@fluentui/*`, `react-redux`, `axios`, `react-router-dom`, etc.)
+  2. Third-party libraries (`@fluentui/*`, `react-redux`, `react-router-dom`, etc.)
   3. Internal modules — hooks, services, store, types
   4. Sibling / relative components
   5. Style imports (`.scss`, `.css`)

--- a/src/ContentProcessorWeb/.github/instructions/test-quality.instructions.md
+++ b/src/ContentProcessorWeb/.github/instructions/test-quality.instructions.md
@@ -114,7 +114,7 @@ Rules:
 | `describe` block  | PascalCase component/function name  | `describe('Header', …)`                 |
 | `it` block        | starts with "should …"             | `it('should show the logo', …)`          |
 | Helper function   | `create…` / `render…` / `mock…`    | `createMockStore`, `renderHeader`        |
-| Mock file         | `__mocks__/<module>.ts`             | `__mocks__/axios.ts`                     |
+| Mock file         | `__mocks__/<module>.ts`             | `__mocks__/httpUtility.ts`               |
 
 File naming must mirror the source module:
 ```
@@ -139,7 +139,7 @@ Focus on UNIT-TESTABLE code — pure logic and isolated components:
 
 **MEDIUM PRIORITY** (test with mocks):
 - **Components with Redux**: use `renderWithProviders` with a preloaded state
-- **Components with API calls**: mock `axios` / `httpUtility` to return controlled data
+- **Components with API calls**: mock `httpUtility` to return controlled data
 - **MSAL-protected components**: mock `useAuth` / `useMsal` hooks
 - **Components with router dependencies**: wrap in `<MemoryRouter>` with initial entries
 
@@ -229,7 +229,7 @@ import '@testing-library/jest-dom';
 
 Use these patterns in order of preference:
 
-### a) `jest.mock` — module-level mocks (axios, services, MSAL)
+### a) `jest.mock` — module-level mocks (services, MSAL)
 
 ```ts
 jest.mock('../../Services/httpUtility', () => ({

--- a/src/ContentProcessorWeb/package.json
+++ b/src/ContentProcessorWeb/package.json
@@ -11,7 +11,6 @@
     "@fluentui/react-dialog": "^9.16.6",
     "@fluentui/react-icons": "^2.0.245",
     "@reduxjs/toolkit": "^2.11.2",
-    "axios": "^1.13.5",
     "babel-preset-react-app": "^10.1.0",
     "contentprocessor_web": "file:",
     "cra-template-typescript": "1.3.0",

--- a/src/ContentProcessorWeb/pnpm-lock.yaml
+++ b/src/ContentProcessorWeb/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       '@reduxjs/toolkit':
         specifier: ^2.11.2
         version: 2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
-      axios:
-        specifier: ^1.13.5
-        version: 1.14.0
       babel-preset-react-app:
         specifier: ^10.1.0
         version: 10.1.0
@@ -10602,7 +10599,6 @@ snapshots:
       '@fluentui/react-dialog': 9.16.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.2)
       '@fluentui/react-icons': 2.0.318(react@18.3.1)
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
-      axios: 1.14.0
       babel-preset-react-app: 10.1.0
       cra-template-typescript: 1.3.0
       i18next: 25.8.4(typescript@4.9.5)


### PR DESCRIPTION
## Purpose

This pull request removes the unused direct `axios` dependency from the frontend `package.json`. All HTTP calls in the app use native `fetch` via `apiClient.tsx`, making the direct axios package unnecessary. This reduces the bundle size and removes an unnecessary dependency from the project.

**Dependency cleanup:**

* Removed `axios: ^1.13.5` from `package.json` dependencies
* Updated `pnpm-lock.yaml` to reflect the removal of direct axios lockfile entries

**Documentation updates:**

* Updated `.github/instructions/test-quality.instructions.md` to remove axios references and replace with httpUtility patterns
* Updated `.github/instructions/code-quality.instructions.md` to remove axios from import hygiene example

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* All 125 unit tests pass
* Local build succeeds (bundle size: 422.76 KB, 303 B smaller)
* Docker image built and deployed to Azure Container Apps — verified HTTP 200
* No direct axios imports exist in any source files

## Other Information

* `react-tiff` (devDependency) still pulls axios as a transitive dependency in the lockfile — this is expected and does not affect the direct dependency surface

Resolves AB#39065