### PR TITLE
fix: Fixed all the code quality issues

### DIFF
--- a/infra/scripts/validate_bicep_params.py
+++ b/infra/scripts/validate_bicep_params.py
@@ -108,7 +108,9 @@ def parse_parameters_env_vars(json_path: Path) -> dict[str, list[str]]:
         data = json.loads(sanitized)
         params = data.get("parameters", {})
     except json.JSONDecodeError:
-        pass
+        # Keep validation resilient for partially templated/malformed files:
+        # if JSON parsing fails, treat as having no parsable parameters.
+        params = {}
 
     # Walk each top-level parameter and scan its entire serialized value
     # for ${VAR} references from the original text.

--- a/src/ContentProcessor/src/libs/agent_framework/agent_framework_helper.py
+++ b/src/ContentProcessor/src/libs/agent_framework/agent_framework_helper.py
@@ -143,7 +143,7 @@ class AgentFrameworkHelper:
         env_file_encoding: str | None = None,
         instruction_role: str | None = None,
     ) -> "AzureOpenAIChatClient":
-        ...
+        pass
 
     @overload
     @staticmethod
@@ -166,7 +166,7 @@ class AgentFrameworkHelper:
         instruction_role: str | None = None,
         retry_config: RateLimitRetryConfig | None = None,
     ) -> AzureOpenAIChatClientWithRetry:
-        ...
+        pass
 
     @overload
     @staticmethod
@@ -190,7 +190,7 @@ class AgentFrameworkHelper:
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
     ) -> "AzureOpenAIAssistantsClient":
-        ...
+        pass
 
     @overload
     @staticmethod
@@ -212,7 +212,7 @@ class AgentFrameworkHelper:
         env_file_encoding: str | None = None,
         instruction_role: str | None = None,
     ) -> "AzureOpenAIResponsesClient":
-        ...
+        pass
 
     @overload
     @staticmethod
@@ -235,7 +235,7 @@ class AgentFrameworkHelper:
         instruction_role: str | None = None,
         retry_config: RateLimitRetryConfig | None = None,
     ) -> AzureOpenAIResponseClientWithRetry:
-        ...
+        pass
 
     @overload
     @staticmethod
@@ -252,7 +252,7 @@ class AgentFrameworkHelper:
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
     ) -> "AzureAIAgentClient":
-        ...
+        pass
 
     @staticmethod
     def create_client(

--- a/src/ContentProcessor/src/libs/agent_framework/azure_openai_response_retry.py
+++ b/src/ContentProcessor/src/libs/agent_framework/azure_openai_response_retry.py
@@ -616,8 +616,15 @@ class AzureOpenAIResponseClientWithRetry(AzureOpenAIResponsesClient):
                 if callable(close):
                     try:
                         await close()
-                    except Exception:
-                        pass
+                    except Exception as close_exc:
+                        # Best-effort stream cleanup: ignore close failures so we preserve
+                        # the original exception/retry path.
+                        logger.debug(
+                            "[AOAI_RETRY_STREAM] ignoring stream close failure during retry handling: %s",
+                            _format_exc_brief(close_exc)
+                            if isinstance(close_exc, BaseException)
+                            else str(close_exc),
+                        )
 
                 # One-shot retry for context-length failures.
                 if (
@@ -802,8 +809,13 @@ class AzureOpenAIChatClientWithRetry(AzureOpenAIChatClient):
                 if callable(close):
                     try:
                         await close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Intentionally suppress close-time failures so we do not
+                        # mask the original streaming exception that triggered retry handling.
+                        logger.debug(
+                            "[AOAI_RETRY_STREAM] ignoring stream close failure during error handling",
+                            exc_info=close_error,
+                        )
 
                 # One-shot retry for context-length failures.
                 if (

--- a/src/ContentProcessorAPI/app/application.py
+++ b/src/ContentProcessorAPI/app/application.py
@@ -53,6 +53,7 @@ class Application(Application_Base):
 
     def __init__(self):
         super().__init__(env_file_path=os.path.join(os.path.dirname(__file__), ".env"))
+        self.bootstrap()
 
     def initialize(self):
         """Build the FastAPI app, attach middleware, routers, and dependencies.

--- a/src/ContentProcessorAPI/app/libs/azure/storage_blob/helper.py
+++ b/src/ContentProcessorAPI/app/libs/azure/storage_blob/helper.py
@@ -7,6 +7,7 @@ Used by the content-processing router to persist uploaded documents and
 retrieve them during downstream pipeline stages.
 """
 
+from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient
 
 from app.utils.azure_credential_utils import get_azure_credential
@@ -124,7 +125,8 @@ class StorageBlobHelper:
         container_client = self._get_container_client(container_name)
         try:
             container_client.delete_blob(blob_name)
-        except Exception:
+        except ResourceNotFoundError:
+            # Blob already absent; continue with folder cleanup checks.
             pass
 
         blobs = container_client.list_blobs()

--- a/src/ContentProcessorAPI/app/libs/base/application_base.py
+++ b/src/ContentProcessorAPI/app/libs/base/application_base.py
@@ -4,8 +4,10 @@
 """Abstract base for the application bootstrap sequence.
 
 Orchestrates the startup order: load .env → read Azure App Configuration →
-populate AppContext with configuration and credentials → configure logging →
-call the concrete ``initialize()`` implemented by the subclass.
+populate AppContext with configuration and credentials → configure logging.
+The concrete ``initialize()`` hook is invoked
+explicitly via ``bootstrap()``
+after construction is complete.
 """
 
 import inspect
@@ -53,14 +55,13 @@ class Application_Base(ABC):
         )
 
     def __init__(self, env_file_path: str | None = None, **data):
-        """Execute the full bootstrap sequence.
+        """Execute base bootstrap setup.
 
         Steps:
             1. Load ``.env`` from *env_file_path* (or derive from subclass location).
             2. Read Azure App Configuration and inject values into ``os.environ``.
             3. Populate ``application_context`` with config and Azure credentials.
             4. Configure Python logging if enabled in config.
-            5. Call ``self.initialize()``.
 
         Args:
             env_file_path: Explicit path to a ``.env`` file (optional).
@@ -103,6 +104,8 @@ class Application_Base(ABC):
                 ):
                     logging.getLogger(logger_name).setLevel(azure_level)
 
+    def bootstrap(self):
+        """Run subclass initialization after construction has completed."""
         self.initialize()
 
     def _load_env(self, env_file_path: str | None = None):

--- a/src/ContentProcessorAPI/app/libs/base/fastapi_protocol.py
+++ b/src/ContentProcessorAPI/app/libs/base/fastapi_protocol.py
@@ -24,7 +24,7 @@ class FastAPIWithContext(Protocol):
     app_context: AppContext
 
     def include_router(self, *args, **kwargs) -> None:
-        ...
+        pass
 
 
 def add_app_context_to_fastapi(

--- a/src/ContentProcessorAPI/app/routers/claimprocessor.py
+++ b/src/ContentProcessorAPI/app/routers/claimprocessor.py
@@ -166,8 +166,10 @@ async def delete_claim_container(claim_id: str, request: Request = None):
     )
     try:
         claim_processor.delete_claim_container(claim_id=claim_id)
-    except Exception:
-        pass
+    except Exception as ex:
+        # Best-effort cleanup: continue deleting the claim-process record even if
+        # the backing claim container is already missing or cannot be deleted.
+        print(f"Failed to delete claim container for '{claim_id}': {ex}")
 
     batch_process_repository: ClaimBatchProcessRepository = app.app_context.get_service(
         ClaimBatchProcessRepository

--- a/src/ContentProcessorWeb/src/Components/Header/Header.tsx
+++ b/src/ContentProcessorWeb/src/Components/Header/Header.tsx
@@ -8,7 +8,7 @@
 
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useHeaderHooks, Header } from "../../Hooks/useHeaderHooks";
+import { Header } from "../../Hooks/useHeaderHooks";
 import {
   TabList,
   Tab,

--- a/src/ContentProcessorWeb/src/Components/UploadContent/UploadFilesModal.tsx
+++ b/src/ContentProcessorWeb/src/Components/UploadContent/UploadFilesModal.tsx
@@ -337,7 +337,7 @@ const UploadFilesModal: React.FC<UploadFilesModalProps> = ({ open, onClose }) =>
     setFileErrors({})
     setUploadCompleted(false);
     setFileSchemas({});
-  }
+  };
   const onCloseHandler = () => {
     resetState();
     onClose();

--- a/src/ContentProcessorWeb/src/Hooks/useFileType.test.ts
+++ b/src/ContentProcessorWeb/src/Hooks/useFileType.test.ts
@@ -5,7 +5,7 @@
  * @file Tests for useFileType — MIME type resolution based on file extension.
  */
 
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import useFileType from './useFileType';
 import type { FileWithExtension } from './useFileType';
 

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/Components/ProcessQueueGrid/ProcessQueueGrid.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/Components/ProcessQueueGrid/ProcessQueueGrid.tsx
@@ -18,9 +18,7 @@ import {
 import { Tooltip, Button } from "@fluentui/react-components";
 import {
     TableBody, TableCell, TableRow, Table,
-    TableHeader, TableHeaderCell, TableCellLayout, createTableColumn, useTableFeatures,
-    useTableSelection, useTableSort, TableColumnId, 
-    TableRowId
+    TableHeader, TableHeaderCell, TableCellLayout
 } from "@fluentui/react-components";
 
 import { useDispatch, useSelector, shallowEqual } from "react-redux";

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelCenter.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelCenter.tsx
@@ -34,7 +34,6 @@ import {
   saveClaimComment,
   fetchContentJsonData,
   setActiveProcessId,
-  setModifiedResult,
 } from '../../store/slices/centerPanelSlice';
 import { startLoader, stopLoader } from "../../store/slices/loaderSlice";
 import { setRefreshGrid } from "../../store/slices/leftPanelSlice";

--- a/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelRight.tsx
+++ b/src/ContentProcessorWeb/src/Pages/DefaultPage/PanelRight.tsx
@@ -14,7 +14,6 @@ import { bundleIcon, ChevronDoubleLeft20Filled, ChevronDoubleLeft20Regular } fro
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { AppDispatch, RootState } from '../../store';
 import { fetchContentFileData } from '../../store/slices/rightPanelSlice';
-import { updatePanelCollapse } from "../../store/slices/defaultPageSlice";
 
 import PanelToolbar from "../../Hooks/usePanelHooks";
 import DocumentViewer from '../../Components/DocumentViewer/DocumentViewer';

--- a/src/ContentProcessorWeb/src/store/slices/centerPanelSlice.test.ts
+++ b/src/ContentProcessorWeb/src/store/slices/centerPanelSlice.test.ts
@@ -118,7 +118,6 @@ describe('centerPanelSlice', () => {
         });
 
         it('should set cError and clear contentData on rejected', () => {
-            const error = new Error('Server error');
             const action = {
                 type: fetchContentJsonData.rejected.type,
                 error: { message: 'Server error' },

--- a/src/ContentProcessorWorkflow/src/libs/agent_framework/agent_framework_helper.py
+++ b/src/ContentProcessorWorkflow/src/libs/agent_framework/agent_framework_helper.py
@@ -142,7 +142,8 @@ class AgentFrameworkHelper:
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
         instruction_role: str | None = None,
-    ) -> "AzureOpenAIChatClient": ...
+    ) -> "AzureOpenAIChatClient":
+        pass
 
     @overload
     @staticmethod
@@ -164,7 +165,8 @@ class AgentFrameworkHelper:
         env_file_encoding: str | None = None,
         instruction_role: str | None = None,
         retry_config: RateLimitRetryConfig | None = None,
-    ) -> AzureOpenAIChatClientWithRetry: ...
+    ) -> AzureOpenAIChatClientWithRetry:
+        pass
 
     @overload
     @staticmethod
@@ -187,7 +189,8 @@ class AgentFrameworkHelper:
         async_client: object | None = None,
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
-    ) -> "AzureOpenAIAssistantsClient": ...
+    ) -> "AzureOpenAIAssistantsClient":
+        raise NotImplementedError
 
     @overload
     @staticmethod
@@ -208,7 +211,8 @@ class AgentFrameworkHelper:
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
         instruction_role: str | None = None,
-    ) -> "AzureOpenAIResponsesClient": ...
+    ) -> "AzureOpenAIResponsesClient":
+        pass
 
     @overload
     @staticmethod
@@ -230,7 +234,8 @@ class AgentFrameworkHelper:
         env_file_encoding: str | None = None,
         instruction_role: str | None = None,
         retry_config: RateLimitRetryConfig | None = None,
-    ) -> AzureOpenAIResponseClientWithRetry: ...
+    ) -> AzureOpenAIResponseClientWithRetry:
+        raise NotImplementedError
 
     @overload
     @staticmethod
@@ -246,7 +251,8 @@ class AgentFrameworkHelper:
         async_credential: object | None = None,
         env_file_path: str | None = None,
         env_file_encoding: str | None = None,
-    ) -> "AzureAIAgentClient": ...
+    ) -> "AzureAIAgentClient":
+        pass
 
     @staticmethod
     def create_client(

--- a/src/ContentProcessorWorkflow/src/libs/agent_framework/azure_openai_response_retry.py
+++ b/src/ContentProcessorWorkflow/src/libs/agent_framework/azure_openai_response_retry.py
@@ -679,8 +679,15 @@ class AzureOpenAIResponseClientWithRetry(AzureOpenAIResponsesClient):
                 if callable(close):
                     try:
                         await close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Best-effort cleanup: ignore close failures so we preserve
+                        # retry/original-error handling behavior.
+                        logger.debug(
+                            "[AOAI_RETRY_STREAM] ignored stream close error during cleanup: %s",
+                            _format_exc_brief(close_error)
+                            if isinstance(close_error, BaseException)
+                            else str(close_error),
+                        )
 
                 # One-shot retry for context-length failures.
                 if (
@@ -865,8 +872,13 @@ class AzureOpenAIChatClientWithRetry(AzureOpenAIChatClient):
                 if callable(close):
                     try:
                         await close()
-                    except Exception:
-                        pass
+                    except Exception as close_err:
+                        logger.debug(
+                            "[AOAI_RETRY_STREAM] ignoring stream close error during cleanup: %s",
+                            _format_exc_brief(close_err)
+                            if isinstance(close_err, BaseException)
+                            else str(close_err),
+                        )
 
                 # One-shot retry for context-length failures.
                 if (

--- a/src/ContentProcessorWorkflow/src/main_service.py
+++ b/src/ContentProcessorWorkflow/src/main_service.py
@@ -370,8 +370,11 @@ async def run_queue_service(
         try:
             if app.queue_service:
                 await app.queue_service.stop_service()
-        except Exception:
-            pass
+        except Exception as cleanup_error:
+            logger.debug(
+                "Ignoring cleanup error while re-raising original failure: %s",
+                cleanup_error,
+            )
         raise
 
 

--- a/src/ContentProcessorWorkflow/src/services/content_process_service.py
+++ b/src/ContentProcessorWorkflow/src/services/content_process_service.py
@@ -10,6 +10,7 @@ Easy Auth sidecar issues for internal service-to-service traffic.
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import uuid
@@ -295,7 +296,7 @@ class ContentProcessService:
 
             if on_poll is not None:
                 poll_handler = on_poll(result)
-                if asyncio.iscoroutine(poll_handler):
+                if inspect.isawaitable(poll_handler):
                     await poll_handler
 
             status = result.get("status", "processing")

--- a/src/ContentProcessorWorkflow/src/services/queue_service.py
+++ b/src/ContentProcessorWorkflow/src/services/queue_service.py
@@ -106,8 +106,12 @@ def parse_claim_task_parameters_from_queue_content(
         try:
             content = decoded.decode("utf-8")
         except UnicodeDecodeError:
+            # Decoded bytes are not UTF-8; keep original content and let the
+            # JSON validation path below raise a clear payload-format error.
             pass
     except Exception:
+        # Not valid base64 (common for plain JSON payloads); keep original
+        # content and continue normal JSON parsing.
         pass
 
     content = content.strip()
@@ -410,18 +414,27 @@ class ClaimProcessingQueueService:
             if self.main_queue:
                 self.main_queue.close()
         except Exception:
-            pass
+            logger.debug(
+                "Ignoring error while closing main queue client during shutdown.",
+                exc_info=True,
+            )
 
         try:
             if self.dead_letter_queue:
                 self.dead_letter_queue.close()
         except Exception:
-            pass
+            logger.debug(
+                "Ignoring dead-letter queue close error during shutdown.",
+                exc_info=True,
+            )
 
         try:
             self.queue_service.close()
         except Exception:
-            pass
+            logger.debug(
+                "Ignoring error while closing queue service client during shutdown.",
+                exc_info=True,
+            )
 
     async def force_stop(self):
         """Alias for ``stop_service()`` (stop already cancels worker tasks)."""
@@ -510,8 +523,15 @@ class ClaimProcessingQueueService:
                     process_id,
                     target_worker_id,
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                # Best-effort kill path: preserve behavior by not failing the
+                # request, but record unexpected cancellation/await errors.
+                logger.warning(
+                    "Unexpected error while finalizing cancellation for process_id=%s worker_id=%s: %s",
+                    process_id,
+                    target_worker_id,
+                    exc,
+                )
 
         return True
 
@@ -1003,7 +1023,7 @@ class ClaimProcessingQueueService:
             except Exception as e:
                 workflow_error = e
             finally:
-                claim_processor = None
+                pass
 
             execution_time = time.time() - message_start_time
 
@@ -1069,8 +1089,15 @@ class ClaimProcessingQueueService:
                     claim_process_id_for_cleanup=None,
                     worker_id=worker_id,
                 )
-            except Exception:
-                pass
+            except Exception as dead_letter_error:
+                # Intentionally swallow to keep worker loop alive in this last-resort path.
+                # We still log the failure for diagnostics/alerting.
+                logger.exception(
+                    "[worker %s] failed while handling fallback failure path for message_id=%s: %s",
+                    worker_id,
+                    getattr(queue_message, "id", "<unknown>"),
+                    dead_letter_error,
+                )
         finally:
             if renew_task is not None:
                 renew_task.cancel()
@@ -1280,7 +1307,11 @@ class ClaimProcessingQueueService:
                             visibility_timeout=max(60, retry_delay_s),
                         )
             except Exception:
-                pass
+                logger.exception(
+                    "Failed to extend visibility timeout after DLQ send failure; message may be retried sooner than expected (message_id=%s worker_id=%s)",
+                    getattr(queue_message, "id", None),
+                    worker_id,
+                )
             return
 
         # Cleanup:

--- a/src/ContentProcessorWorkflow/src/utils/http_request.py
+++ b/src/ContentProcessorWorkflow/src/utils/http_request.py
@@ -18,6 +18,7 @@ Provides:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import time
 from dataclasses import dataclass
@@ -162,6 +163,8 @@ class _WaitRetryAfterOrExponential:
                     if ra is not None:
                         return min(max(ra, self._min), self._max)
         except Exception:
+            # Intentionally ignore non-critical errors while inspecting Retry-After
+            # and fall back to exponential backoff below.
             pass
 
         attempt = max(retry_state.attempt_number, 1)
@@ -580,6 +583,7 @@ class HttpRequestClient:
                 try:
                     h.close()
                 except Exception:
+                    # Best-effort cleanup: do not let close() failures mask the main request result.
                     pass
 
     async def poll_until_done(
@@ -630,7 +634,7 @@ class HttpRequestClient:
 
             if on_poll is not None:
                 maybe_awaitable = on_poll(resp)
-                if asyncio.iscoroutine(maybe_awaitable):
+                if inspect.isawaitable(maybe_awaitable):
                     await maybe_awaitable
 
             if resp.status in done:

--- a/src/ContentProcessorWorkflow/tests/conftest.py
+++ b/src/ContentProcessorWorkflow/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 """Shared pytest fixtures and configuration for the test suite."""
 
+import importlib
 import sys
 from pathlib import Path
 
@@ -17,7 +18,7 @@ if str(_SRC_DIR) not in sys.path:
 # pick up our `src/sitecustomize.py` unless `PYTHONPATH=src` is set. Import it
 # explicitly after adding `src/` to `sys.path` so test collection works.
 try:
-    import sitecustomize  # noqa: F401
+    importlib.import_module("sitecustomize")
 except Exception:
     # Tests should still be able to run even if the compatibility hook is absent.
     pass

--- a/src/ContentProcessorWorkflow/tests/unit/libs/application/test_application_context_di.py
+++ b/src/ContentProcessorWorkflow/tests/unit/libs/application/test_application_context_di.py
@@ -33,7 +33,7 @@ class TestSingleton:
         assert a is b
 
     def test_with_factory(self) -> None:
-        ctx = AppContext().add_singleton(_S1, lambda: _S1())
+        ctx = AppContext().add_singleton(_S1, _S1)
         a = ctx.get_service(_S1)
         b = ctx.get_service(_S1)
         assert a is b

--- a/src/ContentProcessorWorkflow/tests/unit/steps/test_rai_executor.py
+++ b/src/ContentProcessorWorkflow/tests/unit/steps/test_rai_executor.py
@@ -22,7 +22,6 @@ from steps.rai.model.rai_response import RAIResponse
 # The @handler decorator in agent_framework validates type annotations at
 # import time, which fails in the test environment.  Patch it to a no-op
 # before importing the executor module.
-_orig_handler = sys.modules.get("agent_framework", MagicMock()).handler  # type: ignore[union-attr]
 
 with patch("agent_framework.handler", lambda fn: fn):
     from steps.rai.executor.rai_executor import RAIExecutor

--- a/src/ContentProcessorWorkflow/tests/unit/steps/test_rai_executor.py
+++ b/src/ContentProcessorWorkflow/tests/unit/steps/test_rai_executor.py
@@ -11,7 +11,6 @@ direct-resource-access logic.
 from __future__ import annotations
 
 import asyncio
-import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 


### PR DESCRIPTION
This pull request focuses on improving error handling, code clarity, and initialization patterns across several backend and frontend modules. The main enhancements include more informative exception handling and logging, explicit initialization sequences, and minor code cleanups for better maintainability.

**Backend Improvements**

_Error handling and logging:_
* Replaced broad `except Exception: pass` patterns with explicit error handling and debug logging in stream cleanup routines in `azure_openai_response_retry.py`, ensuring that close failures are logged but do not mask original errors. [[1]](diffhunk://#diff-d77b46e72e7f7ef5dd886485867af0268bbf34b80886bfd6cdfcd370e3b272deL619-R627) [[2]](diffhunk://#diff-d77b46e72e7f7ef5dd886485867af0268bbf34b80886bfd6cdfcd370e3b272deL805-R818) [[3]](diffhunk://#diff-80b2e249b34820ad52a609b251b447d90ee60b93d5d200883c28c48b49d7f402L682-R690) [[4]](diffhunk://#diff-80b2e249b34820ad52a609b251b447d90ee60b93d5d200883c28c48b49d7f402L868-R881)
* In `validate_bicep_params.py`, made JSON parsing failure resilient by treating malformed files as having no parameters instead of silently passing.
* In `delete_blob_and_cleanup`, now only suppresses `ResourceNotFoundError` instead of all exceptions, clarifying intent and avoiding masking real errors.
* In `delete_claim_container`, logs and continues on cleanup exceptions instead of silently ignoring them.

_Initialization and application structure:_
* Refactored application bootstrap: `Application_Base` now separates construction from initialization, requiring explicit `bootstrap()` call after construction, and updated docstrings to reflect this. [[1]](diffhunk://#diff-21256cef27ef17aa56960ab0032a0513ab1c818ce816f71359f7061e43aae457L7-R10) [[2]](diffhunk://#diff-21256cef27ef17aa56960ab0032a0513ab1c818ce816f71359f7061e43aae457L56-L63) [[3]](diffhunk://#diff-21256cef27ef17aa56960ab0032a0513ab1c818ce816f71359f7061e43aae457R107-R108) [[4]](diffhunk://#diff-52d19c7906af9cc36c4a5ce4d95f34bf07aa26099149df988f51ccb77507a881R56)

_Codebase clarity and maintenance:_
* Replaced `...` with `pass` or `raise NotImplementedError` in function stubs for clarity in type hinting and protocol classes. [[1]](diffhunk://#diff-719b44a432118dd75eb9cd24abc800fb20d3054de8ad63e917f40f0b8d45b405L146-R146) [[2]](diffhunk://#diff-719b44a432118dd75eb9cd24abc800fb20d3054de8ad63e917f40f0b8d45b405L169-R169) [[3]](diffhunk://#diff-719b44a432118dd75eb9cd24abc800fb20d3054de8ad63e917f40f0b8d45b405L193-R193) [[4]](diffhunk://#diff-719b44a432118dd75eb9cd24abc800fb20d3054de8ad63e917f40f0b8d45b405L215-R215) [[5]](diffhunk://#diff-719b44a432118dd75eb9cd24abc800fb20d3054de8ad63e917f40f0b8d45b405L238-R238) [[6]](diffhunk://#diff-719b44a432118dd75eb9cd24abc800fb20d3054de8ad63e917f40f0b8d45b405L255-R255) [[7]](diffhunk://#diff-beead93722a35c5d61ba5dc288c17f39c84c5fe280d97694a89824eb4f7b4c44L145-R146) [[8]](diffhunk://#diff-beead93722a35c5d61ba5dc288c17f39c84c5fe280d97694a89824eb4f7b4c44L167-R169) [[9]](diffhunk://#diff-beead93722a35c5d61ba5dc288c17f39c84c5fe280d97694a89824eb4f7b4c44L190-R193) [[10]](diffhunk://#diff-beead93722a35c5d61ba5dc288c17f39c84c5fe280d97694a89824eb4f7b4c44L211-R215) [[11]](diffhunk://#diff-beead93722a35c5d61ba5dc288c17f39c84c5fe280d97694a89824eb4f7b4c44L233-R238) [[12]](diffhunk://#diff-beead93722a35c5d61ba5dc288c17f39c84c5fe280d97694a89824eb4f7b4c44L249-R255) [[13]](diffhunk://#diff-54491fbc9d1737ff61cc4bc60a47a1b8f1e912d51f523d905ac34c0cb9db4ee7L27-R27)

**Frontend and test cleanups**

* Removed unused imports and cleaned up code in several React components and tests for maintainability and clarity. [[1]](diffhunk://#diff-df64650de0490e24db71ed8b60b139a07ac3e067affa6523cb3b2dfccf5a910aL11-R11) [[2]](diffhunk://#diff-ded424437ff8075f5adb1df03854f01126bf4c9bf8be89bacf868de261be3181L340-R340) [[3]](diffhunk://#diff-3436d7cc7a2bfa7b4aed9fa8d472a309ef1bd3d544810df1d9a6eac59c11cfadL8-R8) [[4]](diffhunk://#diff-7a5d3a043adff4db35c234ca00c097170968d7e2cf648b13ed904658c6e9f925L21-R21) [[5]](diffhunk://#diff-3d8f0969f69afcc3f9f7b00d51f438673f2c65f243938d40c52a0c20dffbe080L37) [[6]](diffhunk://#diff-1f3ae7ce7592fee3f089ec0ca27ba13675dab032273968a3aa22834e270757ddL17) [[7]](diffhunk://#diff-47ebecbd002bf7f0d07f3bbbfeb4ce618145de5f715eb6692b3a6b8731b6d8d2L121)

These changes collectively improve the robustness, maintainability, and clarity of both backend and frontend codebases.## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

