### PR TITLE
feat: Add pytest coverage comment to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: write
 jobs:
   backend_tests:
     runs-on: ubuntu-latest
@@ -72,7 +73,19 @@ jobs:
         if: env.skip_backend_tests == 'false'
         run: |
           cd src/ContentProcessor
-          python -m pytest -vv --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=80
+          python -m pytest -vv --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under=80 --junitxml=pytest.xml
+
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          env.skip_backend_tests == 'false'
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: src/ContentProcessor/coverage.xml
+          junitxml-path: src/ContentProcessor/pytest.xml
+          report-only-changed-files: true
 
       - name: Skip Backend Tests
         if: env.skip_backend_tests == 'true'


### PR DESCRIPTION
Add MishaKav/pytest-coverage-comment action to post code coverage summary as a PR comment. Changes include:
- Add pull-requests: write permission
- Add --junitxml=pytest.xml flag for test summary
- Add coverage comment step with per-file breakdown

## Purpose

This pull request updates the GitHub Actions workflow for backend tests to improve test reporting and provide automated coverage feedback on pull requests. The main changes involve updating permissions and integrating a new step to comment test coverage results directly on pull requests.

**Workflow improvements:**

* Added `pull-requests: write` permission to the workflow to allow posting comments on pull requests.

**Test reporting enhancements:**

* Modified the pytest command in the backend test job to generate a JUnit XML report (`--junitxml=pytest.xml`) in addition to coverage reports.
* Added a new step using `MishaKav/pytest-coverage-comment` to automatically post a coverage summary as a comment on pull requests, but only when the PR is not from a fork and backend tests are not skipped.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No
