### PR TITLE
fix: Fix to resolve SFI-W18 policy issue

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -916,12 +916,6 @@ module avmContainerAppEnv 'br/public:avm/res/app/managed-environment:0.11.3' = {
     tags: {
       ...resourceGroup().tags
       ...tags
-      TemplateName: 'Content Processing'
-      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
-      CreatedBy: createdBy
-      DeploymentName: deployment().name
-      app: solutionSuffix
-
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -914,8 +914,14 @@ module avmContainerAppEnv 'br/public:avm/res/app/managed-environment:0.11.3' = {
     name: 'cae-${solutionSuffix}'
     location: location
     tags: {
+      ...resourceGroup().tags
+      ...tags
+      TemplateName: 'Content Processing'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
+      CreatedBy: createdBy
+      DeploymentName: deployment().name
       app: solutionSuffix
-      location: location
+
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "306303044487815506"
+      "templateHash": "18378296288333564754"
     },
     "name": "Content Processing Solution Accelerator",
     "description": "Bicep template to deploy the Content Processing Solution Accelerator with AVM compliance."
@@ -45045,7 +45045,7 @@
             "value": "[parameters('location')]"
           },
           "tags": {
-            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'Content Processing', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'app', variables('solutionSuffix'))))]"
+            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags')))]"
           },
           "managedIdentities": {
             "value": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "5358772599129171911"
+      "version": "0.39.26.7824",
+      "templateHash": "306303044487815506"
     },
     "name": "Content Processing Solution Accelerator",
     "description": "Bicep template to deploy the Content Processing Solution Accelerator with AVM compliance."
@@ -348,8 +348,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "4055670269816744382"
+              "version": "0.39.26.7824",
+              "templateHash": "2779842231546071291"
             }
           },
           "definitions": {
@@ -19225,8 +19225,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "6350282028214740152"
+              "version": "0.39.26.7824",
+              "templateHash": "9967760373683235080"
             }
           },
           "parameters": {
@@ -23231,8 +23231,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13929816981891754138"
+              "version": "0.39.26.7824",
+              "templateHash": "11438993289824448790"
             }
           },
           "parameters": {
@@ -23823,8 +23823,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "17694195801715707119"
+              "version": "0.39.26.7824",
+              "templateHash": "18073394536155497558"
             },
             "name": "Container Registry Module"
           },
@@ -35187,8 +35187,8 @@
         "avmContainerApp_API",
         "avmContainerApp_Workflow",
         "avmManagedIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "virtualNetwork"
       ]
     },
@@ -35308,8 +35308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "11676375352983709807"
+              "version": "0.39.26.7824",
+              "templateHash": "11365341673325597162"
             },
             "name": "Cognitive Services",
             "description": "This module deploys a Cognitive Service."
@@ -36558,8 +36558,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "8716336912243881623"
+                      "version": "0.39.26.7824",
+                      "templateHash": "15006072223125242147"
                     }
                   },
                   "definitions": {
@@ -37522,7 +37522,7 @@
                       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
                       "type": "Microsoft.Authorization/locks",
                       "apiVersion": "2020-05-01",
-                      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+                      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
                       "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
                       "properties": {
                         "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
@@ -37536,7 +37536,7 @@
                       },
                       "type": "Microsoft.Insights/diagnosticSettings",
                       "apiVersion": "2021-05-01-preview",
-                      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+                      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
                       "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
                       "properties": {
                         "copy": [
@@ -37574,7 +37574,7 @@
                       },
                       "type": "Microsoft.Authorization/roleAssignments",
                       "apiVersion": "2022-04-01",
-                      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+                      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
                       "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
                       "properties": {
                         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -38367,8 +38367,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "10989408486030617267"
+                              "version": "0.39.26.7824",
+                              "templateHash": "12797226417049698978"
                             }
                           },
                           "definitions": {
@@ -38521,8 +38521,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "7933643033523871028"
+                              "version": "0.39.26.7824",
+                              "templateHash": "422299638943108486"
                             }
                           },
                           "definitions": {
@@ -38739,8 +38739,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "8716336912243881623"
+                      "version": "0.39.26.7824",
+                      "templateHash": "15006072223125242147"
                     }
                   },
                   "definitions": {
@@ -39703,7 +39703,7 @@
                       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
                       "type": "Microsoft.Authorization/locks",
                       "apiVersion": "2020-05-01",
-                      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+                      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
                       "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
                       "properties": {
                         "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
@@ -39717,7 +39717,7 @@
                       },
                       "type": "Microsoft.Insights/diagnosticSettings",
                       "apiVersion": "2021-05-01-preview",
-                      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+                      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
                       "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
                       "properties": {
                         "copy": [
@@ -39755,7 +39755,7 @@
                       },
                       "type": "Microsoft.Authorization/roleAssignments",
                       "apiVersion": "2022-04-01",
-                      "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]",
+                      "scope": "[format('Microsoft.CognitiveServices/accounts/{0}', parameters('name'))]",
                       "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
                       "properties": {
                         "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
@@ -40548,8 +40548,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "10989408486030617267"
+                              "version": "0.39.26.7824",
+                              "templateHash": "12797226417049698978"
                             }
                           },
                           "definitions": {
@@ -40702,8 +40702,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "7933643033523871028"
+                              "version": "0.39.26.7824",
+                              "templateHash": "422299638943108486"
                             }
                           },
                           "definitions": {
@@ -41721,10 +41721,10 @@
       },
       "dependsOn": [
         "avmAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').contentUnderstanding)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').contentUnderstanding)]",
         "virtualNetwork"
       ]
     },
@@ -45022,9 +45022,9 @@
       },
       "dependsOn": [
         "avmAiServices_cu",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').contentUnderstanding)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "virtualNetwork"
       ]
     },
@@ -45045,10 +45045,7 @@
             "value": "[parameters('location')]"
           },
           "tags": {
-            "value": {
-              "app": "[variables('solutionSuffix')]",
-              "location": "[parameters('location')]"
-            }
+            "value": "[shallowMerge(createArray(resourceGroup().tags, parameters('tags'), createObject('TemplateName', 'Content Processing', 'Type', if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF'), 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'app', variables('solutionSuffix'))))]"
           },
           "managedIdentities": {
             "value": {
@@ -68557,6 +68554,13 @@
         "description": "The login server of the Azure Container Registry."
       },
       "value": "[reference('avmContainerRegistry').outputs.loginServer.value]"
+    },
+    "CONTENT_UNDERSTANDING_ACCOUNT_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Content Understanding AI Services account."
+      },
+      "value": "[reference('avmAiServices_cu').outputs.name.value]"
     },
     "AZURE_RESOURCE_GROUP": {
       "type": "string",

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -919,11 +919,6 @@ module avmContainerAppEnv 'br/public:avm/res/app/managed-environment:0.11.3' = {
     tags: {
       ...resourceGroup().tags
       ...tags
-      TemplateName: 'Content Processing'
-      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
-      CreatedBy: createdBy
-      DeploymentName: deployment().name
-      app: solutionSuffix
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -917,8 +917,13 @@ module avmContainerAppEnv 'br/public:avm/res/app/managed-environment:0.11.3' = {
     name: 'cae-${solutionSuffix}'
     location: location
     tags: {
+      ...resourceGroup().tags
+      ...tags
+      TemplateName: 'Content Processing'
+      Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
+      CreatedBy: createdBy
+      DeploymentName: deployment().name
       app: solutionSuffix
-      location: location
     }
     managedIdentities: { systemAssigned: true }
     appLogsConfiguration: enableMonitoring


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure templates for the Content Processing Solution Accelerator, focusing on improving tag management, output variables, and resource dependency ordering. There are also minor fixes to resource scoping and generator metadata.

**Key changes:**

Tag and Metadata Improvements:
* Updated the tags for the managed environment in both `infra/main.bicep` and `infra/main_custom.bicep` to include resource group tags, custom tags, template name, deployment type, creator, and deployment name, while removing the redundant `location` tag. This ensures richer and more consistent metadata across resources. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R917-R924) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62R920-L921) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L45048-R45048)

Output and Variable Additions:
* Added a new output variable `CONTENT_UNDERSTANDING_ACCOUNT_NAME` to `infra/main.json` to expose the Content Understanding AI Services account name for downstream use.

Resource Dependency and Ordering Fixes:
* Corrected the order of dependencies in several `dependsOn` arrays in `infra/main.json` to ensure resources are created in the correct sequence, which can help avoid deployment issues. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L35190-R35191) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L41724-R41727) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L45025-R45027)

Resource Scope and Reference Fixes:
* Updated several resource `scope` definitions in `infra/main.json` to use the correct string formatting for referencing Cognitive Services accounts, improving reliability and consistency. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L37525-R37525) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L37539-R37539) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L37577-R37577) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39706-R39706) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39720-R39720) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39758-R39758)

Template Generator Metadata:
* Updated the Bicep generator version and template hash metadata in multiple locations within `infra/main.json`, reflecting the use of a different Bicep compiler version. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L351-R352) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19228-R19229) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L23234-R23235) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L23826-R23827) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L35311-R35312) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L36561-R36562) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L38370-R38371) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L38524-R38525) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L38742-R38743) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L40551-R40552) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L40705-R40706)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

