### PR TITLE
fix: comments in code & broken link checker issue fix

### DIFF
--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -37,7 +37,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.8.0
         with:
           args: >
-            --verbose --no-progress --exclude ^https?://
+            --verbose --no-progress --exclude ^https?:// --root-dir .
             ${{ steps.changed-markdown-files.outputs.all_changed_files }}
           failIfEmpty: false
         env:
@@ -50,7 +50,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.8.0
         with:
           args: >
-            --verbose --no-progress --exclude ^https?://
+            --verbose --no-progress --exclude ^https?:// --root-dir .
             '**/*.md'
           failIfEmpty: false
         env:

--- a/src/ContentProcessor/src/libs/utils/remote_schema_loader.py
+++ b/src/ContentProcessor/src/libs/utils/remote_schema_loader.py
@@ -103,7 +103,13 @@ def _download_blob_content(
     blob_client = blob_service_client.get_blob_client(
         container=container_name, blob=blob_name
     )
-    return blob_client.download_blob().readall().decode("utf-8")
+    raw_bytes = blob_client.download_blob().readall()
+    try:
+        return raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise JsonSchemaLoadError(
+            f"Schema blob '{blob_name}' is not valid UTF-8."
+        ) from exc
 
 
 class _ModelBuilder:
@@ -293,7 +299,7 @@ class _ModelBuilder:
             name = ref[len(prefix_definitions):]
         else:
             raise JsonSchemaLoadError(
-                f"Only local '#/$defs/...' refs are supported (got '{ref}')."
+                f"Only local '#/$defs/...' and '#/definitions/...' refs are supported (got '{ref}')."
             )
 
         if name in self._models:

--- a/src/ContentProcessorAPI/app/routers/logics/schema_validator.py
+++ b/src/ContentProcessorAPI/app/routers/logics/schema_validator.py
@@ -55,7 +55,7 @@ def validate_json_schema(raw_bytes: bytes) -> dict[str, Any]:
     """
     errors: list[str] = []
 
-    if raw_bytes is None:
+    if not raw_bytes:
         raise SchemaValidationError(["Empty schema upload."])
 
     if len(raw_bytes) > MAX_SCHEMA_BYTES:
@@ -139,6 +139,9 @@ def derive_class_name(document: dict[str, Any], fallback: str) -> str:
     else:
         candidate = fallback
 
+    # Apply identifier sanitization to all candidates (including title) so
+    # that titles containing spaces/dashes/etc. cannot produce invalid
+    # Python class names downstream.
     cleaned = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in candidate)
     if not cleaned or not (cleaned[0].isalpha() or cleaned[0] == "_"):
         cleaned = "Schema_" + cleaned

--- a/src/ContentProcessorAPI/app/routers/logics/schemavault.py
+++ b/src/ContentProcessorAPI/app/routers/logics/schemavault.py
@@ -3,6 +3,8 @@
 
 """Business logic for individual schema registration, update, and deletion."""
 
+from typing import Literal
+
 from fastapi import UploadFile
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -72,7 +74,7 @@ class Schemas(BaseModel):
         file: UploadFile,
         schema_id: str,
         class_name: str,
-        storage_format: str = "json",
+        storage_format: Literal["json"] = "json",
     ) -> Schema:
         """Replace the schema file in blob storage and update Cosmos metadata."""
         schemas = self.mongoHelper.find_document(query={"Id": schema_id})


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces several improvements and fixes across the schema validation and loading logic, as well as minor workflow enhancements. The most notable changes include improved error handling for schema encoding, stricter validation of schema uploads, and better support for schema reference formats.

**Schema validation and loading improvements:**

* Improved error handling in `_download_blob_content`: Now raises a `JsonSchemaLoadError` with a clear message if the schema blob is not valid UTF-8, instead of failing with a generic decode error.
* Enhanced reference support in `_resolve_ref`: The error message now clarifies that both `#/$defs/...` and `#/definitions/...` local refs are supported, improving developer feedback.
* Stricter validation in `validate_json_schema`: The check for empty schema uploads now correctly handles all falsy values for `raw_bytes`, preventing potential issues with empty files.
* Improved class name derivation in `derive_class_name`: All candidate class names, including those from schema titles, are sanitized to ensure valid Python identifiers, preventing downstream errors.

**Type and workflow enhancements:**

* Changed the `storage_format` parameter in the `Update` method to use a `Literal["json"]` type, ensuring type safety and clarity.
* Updated the broken links checker workflow (`.github/workflows/broken-links-checker.yml`) to explicitly set the root directory for link checks, making the workflow more robust in different environments. [[1]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L40-R40) [[2]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L53-R53)
* Added an explicit import of `Literal` in `schemavault.py` to support the new type annotation.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

