### PR TITLE
fix: fixed copilot comments

### DIFF
--- a/.github/workflows/job-send-notification.yml
+++ b/.github/workflows/job-send-notification.yml
@@ -130,6 +130,17 @@ jobs:
           EXP_LABEL=$( [ "$EXP" = "true" ] && echo "EXP" || echo "Non-EXP" )
           echo "CONFIG_LABEL=${WAF_LABEL} + ${EXP_LABEL}" >> $GITHUB_OUTPUT
 
+      - name: Prepare HTML Escape Helper
+        shell: bash
+        run: |
+          HTML_ESCAPE_HELPER="$RUNNER_TEMP/html_escape_helper.sh"
+          cat > "$HTML_ESCAPE_HELPER" <<'EOF'
+          html_escape() {
+            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
+          }
+          EOF
+          echo "HTML_ESCAPE_HELPER=$HTML_ESCAPE_HELPER" >> "$GITHUB_ENV"
+
       # ------------------------------------------------------------------
       # Quota failure
       # ------------------------------------------------------------------
@@ -144,10 +155,7 @@ jobs:
           CLEANUP_PILL: ${{ steps.cleanup.outputs.CLEANUP_PILL }}
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
         run: |
-          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
-          html_escape() {
-            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
-          }
+          . "$HTML_ESCAPE_HELPER"
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           ACTOR="$(html_escape "$GITHUB_ACTOR")"
           BRANCH="$(html_escape "$BRANCH_NAME")"
@@ -225,10 +233,7 @@ jobs:
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
           CLEANUP_PILL: ${{ steps.cleanup.outputs.CLEANUP_PILL }}
         run: |
-          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
-          html_escape() {
-            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
-          }
+          . "$HTML_ESCAPE_HELPER"
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           RESOURCE_GROUP="$(html_escape "$INPUT_RESOURCE_GROUP_NAME")"
           ACTOR="$(html_escape "$GITHUB_ACTOR")"
@@ -314,10 +319,7 @@ jobs:
           CLEANUP_PILL: ${{ steps.cleanup.outputs.CLEANUP_PILL }}
           TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
-          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
-          html_escape() {
-            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
-          }
+          . "$HTML_ESCAPE_HELPER"
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           WEBAPP_URL="$(html_escape "${INPUT_CONTAINER_WEB_APPURL:-$INPUT_EXISTING_WEBAPP_URL}")"
           RESOURCE_GROUP="$(html_escape "$INPUT_RESOURCE_GROUP_NAME")"
@@ -413,10 +415,7 @@ jobs:
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
           TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
-          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
-          html_escape() {
-            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
-          }
+          . "$HTML_ESCAPE_HELPER"
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           WEBAPP_URL="$(html_escape "${INPUT_CONTAINER_WEB_APPURL:-$INPUT_EXISTING_WEBAPP_URL}")"
           RESOURCE_GROUP="$(html_escape "$INPUT_RESOURCE_GROUP_NAME")"
@@ -504,10 +503,7 @@ jobs:
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
           TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
-          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
-          html_escape() {
-            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
-          }
+          . "$HTML_ESCAPE_HELPER"
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           EXISTING_URL="$(html_escape "$INPUT_EXISTING_WEBAPP_URL")"
           TEST_REPORT_URL="$(html_escape "$INPUT_TEST_REPORT_URL")"
@@ -596,10 +592,7 @@ jobs:
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
           TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
-          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
-          html_escape() {
-            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
-          }
+          . "$HTML_ESCAPE_HELPER"
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           EXISTING_URL="$(html_escape "$INPUT_EXISTING_WEBAPP_URL")"
           TEST_REPORT_URL="$(html_escape "$INPUT_TEST_REPORT_URL")"

--- a/.github/workflows/job-send-notification.yml
+++ b/.github/workflows/job-send-notification.yml
@@ -144,7 +144,13 @@ jobs:
           CLEANUP_PILL: ${{ steps.cleanup.outputs.CLEANUP_PILL }}
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
         run: |
+          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
+          html_escape() {
+            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
+          }
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          ACTOR="$(html_escape "$GITHUB_ACTOR")"
+          BRANCH="$(html_escape "$BRANCH_NAME")"
           PILL_BASE="display:inline-block; min-width:70px; text-align:center; padding:4px 12px; border-radius:20px; font-size:12px; font-weight:600; line-height:1.4;"
           DEPLOY_PILL="<span style=\"${PILL_BASE} background:#f8d7da; color:#721c24;\">&#x274C; FAILED</span>"
           E2E_PILL="<span style=\"${PILL_BASE} background:#d4edda; color:#155724;\">&#x23ED;&#xFE0F; SKIPPED</span>"
@@ -178,9 +184,9 @@ jobs:
                   <h3 style="margin:0 0 14px; font-size:13px; text-transform:uppercase; letter-spacing:0.5px; color:#6b7280; border-bottom:2px solid #e5e7eb; padding-bottom:8px;">Deployment Details</h3>
                   <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:28px;">
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280; width:140px;">Triggered By</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827;">${{ github.actor }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827;">${ACTOR}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Branch</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${{ env.BRANCH_NAME }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${BRANCH}</td></tr>
                   </table>
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:8px 0;">
                     <a href="${RUN_URL}" style="display:inline-block; background:#dc2626; color:#ffffff; text-decoration:none; padding:12px 28px; border-radius:4px; font-size:13px; font-weight:600; letter-spacing:0.3px;">VIEW PIPELINE RUN</a>
@@ -219,8 +225,14 @@ jobs:
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
           CLEANUP_PILL: ${{ steps.cleanup.outputs.CLEANUP_PILL }}
         run: |
+          # HTML-escape values that get embedded into the email template to avoid HTML/attribute injection from workflow inputs.
+          html_escape() {
+            printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&#39;/g"
+          }
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          RESOURCE_GROUP="$INPUT_RESOURCE_GROUP_NAME"
+          RESOURCE_GROUP="$(html_escape "$INPUT_RESOURCE_GROUP_NAME")"
+          ACTOR="$(html_escape "$GITHUB_ACTOR")"
+          BRANCH="$(html_escape "$BRANCH_NAME")"
           PILL_BASE="display:inline-block; min-width:70px; text-align:center; padding:4px 12px; border-radius:20px; font-size:12px; font-weight:600; line-height:1.4;"
           DEPLOY_PILL="<span style=\"${PILL_BASE} background:#f8d7da; color:#721c24;\">&#x274C; FAILED</span>"
           E2E_PILL="<span style=\"${PILL_BASE} background:#d4edda; color:#155724;\">&#x23ED;&#xFE0F; SKIPPED</span>"
@@ -256,9 +268,9 @@ jobs:
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280; width:140px;">Resource Group</td>
                         <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${RESOURCE_GROUP}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Triggered By</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827;">${{ github.actor }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827;">${ACTOR}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Branch</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${{ env.BRANCH_NAME }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${BRANCH}</td></tr>
                   </table>
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:8px 0;">
                     <a href="${RUN_URL}" style="display:inline-block; background:#dc2626; color:#ffffff; text-decoration:none; padding:12px 28px; border-radius:4px; font-size:13px; font-weight:600; letter-spacing:0.3px;">INVESTIGATE FAILURE</a>
@@ -310,6 +322,8 @@ jobs:
           WEBAPP_URL="$(html_escape "${INPUT_CONTAINER_WEB_APPURL:-$INPUT_EXISTING_WEBAPP_URL}")"
           RESOURCE_GROUP="$(html_escape "$INPUT_RESOURCE_GROUP_NAME")"
           TEST_REPORT_URL="$(html_escape "$INPUT_TEST_REPORT_URL")"
+          ACTOR="$(html_escape "$GITHUB_ACTOR")"
+          BRANCH="$(html_escape "$BRANCH_NAME")"
           PILL_BASE="display:inline-block; min-width:70px; text-align:center; padding:4px 12px; border-radius:20px; font-size:12px; font-weight:600; line-height:1.4;"
           DEPLOY_PILL="<span style=\"${PILL_BASE} background:#d4edda; color:#155724;\">&#x2705; SUCCESS</span>"
 
@@ -353,9 +367,9 @@ jobs:
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Web App URL</td>
                         <td style="padding:8px 0; font-size:13px;"><a href="${WEBAPP_URL}" style="color:#2563eb; text-decoration:none; font-family:'Cascadia Code','Courier New',monospace;">${WEBAPP_URL}</a></td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Triggered By</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827;">${{ github.actor }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827;">${ACTOR}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Branch</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${{ env.BRANCH_NAME }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${BRANCH}</td></tr>
                     ${TEST_DETAIL_ROWS}
                   </table>
                   <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:8px 0;">
@@ -407,6 +421,8 @@ jobs:
           WEBAPP_URL="$(html_escape "${INPUT_CONTAINER_WEB_APPURL:-$INPUT_EXISTING_WEBAPP_URL}")"
           RESOURCE_GROUP="$(html_escape "$INPUT_RESOURCE_GROUP_NAME")"
           TEST_REPORT_URL="$(html_escape "$INPUT_TEST_REPORT_URL")"
+          ACTOR="$(html_escape "$GITHUB_ACTOR")"
+          BRANCH="$(html_escape "$BRANCH_NAME")"
           PILL_BASE="display:inline-block; min-width:70px; text-align:center; padding:4px 12px; border-radius:20px; font-size:12px; font-weight:600; line-height:1.4;"
           DEPLOY_PILL="<span style=\"${PILL_BASE} background:#d4edda; color:#155724;\">&#x2705; SUCCESS</span>"
           E2E_PILL="<span style=\"${PILL_BASE} background:#f8d7da; color:#721c24;\">&#x274C; FAILED</span>"
@@ -441,9 +457,9 @@ jobs:
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Web App URL</td>
                         <td style="padding:8px 0; font-size:13px;"><a href="${WEBAPP_URL}" style="color:#2563eb; text-decoration:none; font-family:'Cascadia Code','Courier New',monospace;">${WEBAPP_URL}</a></td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Triggered By</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827;">${{ github.actor }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827;">${ACTOR}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Branch</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${{ env.BRANCH_NAME }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${BRANCH}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Test Suite</td>
                         <td style="padding:8px 0; font-size:13px; color:#111827;">${TEST_SUITE_NAME}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Test Report</td>
@@ -495,6 +511,8 @@ jobs:
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           EXISTING_URL="$(html_escape "$INPUT_EXISTING_WEBAPP_URL")"
           TEST_REPORT_URL="$(html_escape "$INPUT_TEST_REPORT_URL")"
+          ACTOR="$(html_escape "$GITHUB_ACTOR")"
+          BRANCH="$(html_escape "$BRANCH_NAME")"
           PILL_BASE="display:inline-block; min-width:70px; text-align:center; padding:4px 12px; border-radius:20px; font-size:12px; font-weight:600; line-height:1.4;"
           DEPLOY_PILL="<span style=\"${PILL_BASE} background:#d4edda; color:#155724;\">&#x23ED;&#xFE0F; SKIPPED</span>"
           E2E_PILL="<span style=\"${PILL_BASE} background:#d4edda; color:#155724;\">&#x2705; SUCCESS</span>"
@@ -532,9 +550,9 @@ jobs:
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280; width:140px;">Target URL</td>
                         <td style="padding:8px 0; font-size:13px;"><a href="${EXISTING_URL}" style="color:#2563eb; text-decoration:none; font-family:'Cascadia Code','Courier New',monospace;">${EXISTING_URL}</a></td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Triggered By</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827;">${{ github.actor }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827;">${ACTOR}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Branch</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${{ env.BRANCH_NAME }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${BRANCH}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Test Suite</td>
                         <td style="padding:8px 0; font-size:13px; color:#111827;">${TEST_SUITE_NAME}</td></tr>
                     ${REPORT_ROW}
@@ -585,6 +603,8 @@ jobs:
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           EXISTING_URL="$(html_escape "$INPUT_EXISTING_WEBAPP_URL")"
           TEST_REPORT_URL="$(html_escape "$INPUT_TEST_REPORT_URL")"
+          ACTOR="$(html_escape "$GITHUB_ACTOR")"
+          BRANCH="$(html_escape "$BRANCH_NAME")"
           PILL_BASE="display:inline-block; min-width:70px; text-align:center; padding:4px 12px; border-radius:20px; font-size:12px; font-weight:600; line-height:1.4;"
           DEPLOY_PILL="<span style=\"${PILL_BASE} background:#d4edda; color:#155724;\">&#x23ED;&#xFE0F; SKIPPED</span>"
           E2E_PILL="<span style=\"${PILL_BASE} background:#f8d7da; color:#721c24;\">&#x274C; FAILED</span>"
@@ -622,9 +642,9 @@ jobs:
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280; width:140px;">Target URL</td>
                         <td style="padding:8px 0; font-size:13px;"><a href="${EXISTING_URL}" style="color:#2563eb; text-decoration:none; font-family:'Cascadia Code','Courier New',monospace;">${EXISTING_URL}</a></td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Triggered By</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827;">${{ github.actor }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827;">${ACTOR}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Branch</td>
-                        <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${{ env.BRANCH_NAME }}</td></tr>
+                      <td style="padding:8px 0; font-size:13px; color:#111827; font-family:'Cascadia Code','Courier New',monospace;">${BRANCH}</td></tr>
                     <tr><td style="padding:8px 0; font-size:13px; color:#6b7280;">Test Suite</td>
                         <td style="padding:8px 0; font-size:13px; color:#111827;">${TEST_SUITE_NAME}</td></tr>
                     ${REPORT_ROW}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request enhances the security of the email notification workflow by ensuring that dynamic values embedded in email templates are properly HTML-escaped. This prevents potential HTML or attribute injection vulnerabilities from workflow inputs such as actor names, branch names, and resource group names. Additionally, the workflow now consistently uses these escaped variables throughout the email templates for all notification scenarios.

The most important changes are:

**Security Improvements:**
* Introduced a `html_escape` shell function in `.github/workflows/job-send-notification.yml` to sanitize dynamic values before embedding them in email templates, mitigating risks of HTML/attribute injection. [[1]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R147-R153) [[2]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R228-R235)
* Updated all references to workflow inputs (such as `GITHUB_ACTOR`, `BRANCH_NAME`, and `INPUT_RESOURCE_GROUP_NAME`) to use their HTML-escaped versions (e.g., `ACTOR`, `BRANCH`, `RESOURCE_GROUP`) in both the shell scripts and the email templates. [[1]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R228-R235) [[2]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R325-R326) [[3]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R424-R425) [[4]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R514-R515) [[5]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R606-R607)

**Email Template Consistency:**
* Modified the email HTML templates to reference the new escaped variables (`${ACTOR}`, `${BRANCH}`, `${RESOURCE_GROUP}`) instead of the raw workflow inputs, ensuring consistent and secure rendering of user-supplied data in all notification scenarios. [[1]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L181-R189) [[2]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L259-R273) [[3]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L356-R372) [[4]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L444-R462) [[5]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L535-R555) [[6]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L625-R647)

These changes collectively improve the robustness and security of the workflow's email notifications.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

