### PR TITLE
chore(deps): bring dependabot upgrades (#589, #595, #596, #597) onto dev (AB#44960)

### DIFF
--- a/src/ContentProcessor/requirements.txt
+++ b/src/ContentProcessor/requirements.txt
@@ -15,7 +15,7 @@ colorama==0.4.6
 coverage==7.13.5
 cryptography==46.0.7
 dnspython==2.8.0
-idna==3.11
+idna==3.15
 iniconfig==2.3.0
 isodate==0.7.2
 mongomock==4.3.0

--- a/src/ContentProcessorAPI/requirements.txt
+++ b/src/ContentProcessorAPI/requirements.txt
@@ -22,7 +22,7 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.7.1
 httpx==0.28.1
-idna==3.11
+idna==3.15
 isodate==0.7.2
 jinja2==3.1.6
 jsonschema==4.25.1

--- a/src/ContentProcessorWorkflow/pyproject.toml
+++ b/src/ContentProcessorWorkflow/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "sas-cosmosdb==0.1.4",
     "sas-storage==1.0.0",
     "tenacity==9.1.2",
-    "authlib==1.6.11",
+    "authlib==1.6.12",
     "protobuf==6.33.6",
     "cryptography==46.0.7",
     "pyjwt==2.12.1",

--- a/src/ContentProcessorWorkflow/uv.lock
+++ b/src/ContentProcessorWorkflow/uv.lock
@@ -554,14 +554,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.11"
+version = "1.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/30/6691fdc63b35f54a5a65e04fa1e59d827f4d4e8f4a39678ba7d3088ce0c8/authlib-1.6.12.tar.gz", hash = "sha256:0656d8482f28fc8221929d5f35b2bde5d13e10555ebc06b4561b0d622e83b1bd", size = 165368, upload-time = "2026-05-04T08:11:31.826Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/51/9b0b5cd4cf683a02db937a6f9bbebcdc9c56558a7bb3763ce7d3512103c3/authlib-1.6.12-py2.py3-none-any.whl", hash = "sha256:e9229ad7fde610b139dd12f5edbe97eab9ee78bfb85691247e767727850b99ab", size = 244473, upload-time = "2026-05-04T08:11:30.354Z" },
 ]
 
 [[package]]
@@ -2994,7 +2994,7 @@ requires-dist = [
     { name = "agent-framework", specifier = "==1.0.0b260107" },
     { name = "aiohttp", specifier = "==3.13.5" },
     { name = "art", specifier = "==6.5" },
-    { name = "authlib", specifier = "==1.6.11" },
+    { name = "authlib", specifier = "==1.6.12" },
     { name = "azure-ai-agents", specifier = "==1.2.0b5" },
     { name = "azure-ai-inference", specifier = "==1.0.0b9" },
     { name = "azure-ai-projects", specifier = "==2.0.0b3" },

--- a/src/ContentProcessorWorkflow/uv.lock
+++ b/src/ContentProcessorWorkflow/uv.lock
@@ -1747,11 +1747,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Brings the four open Dependabot dependency upgrades onto **`dev`** so they ship to the dev branch ahead of the upstream Dependabot PRs (which all target `main`).

Each commit is a byte-perfect replication of the corresponding Dependabot patch — no transitive re-resolution or lockfile churn beyond what Dependabot itself produced.

## Changes (one commit per upstream PR)

| Commit | Mirrors | Project | Change |
|---|---|---|---|
| 1 | #589 | ContentProcessorWorkflow | `authlib` 1.6.11 → 1.6.12 (`pyproject.toml` + `uv.lock`) |
| 2 | #595 | ContentProcessorAPI | `idna` 3.11 → 3.15 (`requirements.txt`) |
| 3 | #596 | ContentProcessor | `idna` 3.11 → 3.15 (`requirements.txt`) |
| 4 | #597 | ContentProcessorWorkflow | `idna` 3.11 → 3.15 (`uv.lock`) |

## Validation

Locally, in isolated Python 3.12 venvs (one per project, mirroring CI):

- `pip install -r ...` / `pip install -e src/ContentProcessorWorkflow` succeed
- `pip check` reports no dependency conflicts
- `pip show idna` / `pip show authlib` confirm the bumped versions are resolved
- `pytest` (same invocation as `.github/workflows/test.yml`) executes the backend, API, and workflow suites

CI will re-run the full suite on this PR.

## Notes for reviewers

- This PR overlaps in scope with **#605** (which also pulls these four bumps onto `dev` plus broader workflow-pin updates). Whichever merges first will require rebasing or closing the other.
- Each commit stages only the files touched by its source Dependabot PR. There are no incidental edits.
- Source diffs were fetched via `gh pr diff <n>` and applied with `git apply` to preserve byte-for-byte equivalence with Dependabot's output.

## Related

- ADO Work Item **#44960** — *[Content Processing] Review and Validate changes in dependabotchanges branch and Upgrade the Packages from dependabotchanges PR*
- Replaces / coordinates with: #589, #595, #596, #597
- Sibling PR: #605
