### PR TITLE
fix: Fix of bug #46192

### DIFF
--- a/infra/main.json
+++ b/infra/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "5885652317352749587"
+      "version": "0.43.8.12551",
+      "templateHash": "12545195410241248179"
     },
     "name": "Content Processing Solution Accelerator",
     "description": "Bicep template to deploy the Content Processing Solution Accelerator with AVM compliance."
@@ -337,8 +337,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "10219602196309243204"
+              "version": "0.43.8.12551",
+              "templateHash": "13206959925771644022"
             }
           },
           "definitions": {
@@ -19306,8 +19306,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "15098611015028470375"
+              "version": "0.43.8.12551",
+              "templateHash": "13200482898648544945"
             }
           },
           "parameters": {
@@ -23332,8 +23332,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "18123481228095028530"
+              "version": "0.43.8.12551",
+              "templateHash": "15729887991536611208"
             }
           },
           "parameters": {
@@ -23936,8 +23936,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "1869938830611166930"
+              "version": "0.43.8.12551",
+              "templateHash": "8672669912945312056"
             },
             "name": "Container Registry Module"
           },
@@ -36183,8 +36183,8 @@
         "avmContainerApp_API",
         "avmContainerApp_Workflow",
         "avmManagedIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
         "virtualNetwork"
       ]
     },
@@ -36314,8 +36314,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "18336251851332975005"
+              "version": "0.43.8.12551",
+              "templateHash": "9621562991003135575"
             },
             "name": "Cognitive Services",
             "description": "This module deploys a Cognitive Service."
@@ -37574,8 +37574,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "8883353547455396972"
+                      "version": "0.43.8.12551",
+                      "templateHash": "8864856500234357706"
                     }
                   },
                   "definitions": {
@@ -39307,8 +39307,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "13560950051680758953"
+                              "version": "0.43.8.12551",
+                              "templateHash": "312284397710022090"
                             }
                           },
                           "definitions": {
@@ -39461,8 +39461,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "2020223351407601593"
+                              "version": "0.43.8.12551",
+                              "templateHash": "276675105610077046"
                             }
                           },
                           "definitions": {
@@ -39679,8 +39679,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "8883353547455396972"
+                      "version": "0.43.8.12551",
+                      "templateHash": "8864856500234357706"
                     }
                   },
                   "definitions": {
@@ -41412,8 +41412,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "13560950051680758953"
+                              "version": "0.43.8.12551",
+                              "templateHash": "312284397710022090"
                             }
                           },
                           "definitions": {
@@ -41566,8 +41566,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "2020223351407601593"
+                              "version": "0.43.8.12551",
+                              "templateHash": "276675105610077046"
                             }
                           },
                           "definitions": {
@@ -42487,9 +42487,9 @@
       },
       "dependsOn": [
         "avmAiServices",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').contentUnderstanding)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').aiServices)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
         "virtualNetwork"
       ]

--- a/infra/scripts/post_deployment.ps1
+++ b/infra/scripts/post_deployment.ps1
@@ -268,18 +268,26 @@ if ($CU_ACCOUNT_NAME) {
 }
 
 if (-not $CU_ACCOUNT_NAME) {
-    $DiscoveredCuAccount = (az cognitiveservices account list -g $RESOURCE_GROUP --query "[?kind=='AIServices'].name | [0]" -o tsv 2>$null)
-    if ($DiscoveredCuAccount) {
-        Write-Host "  Discovered AIServices account in resource group: $DiscoveredCuAccount"
-        $CU_ACCOUNT_NAME = $DiscoveredCuAccount
+    # Enumerate ALL AIServices accounts (not just the first). When the resource
+    # group contains exactly one we auto-recover; when it contains more than one
+    # we refuse to guess and ask the user to set the env value explicitly, to
+    # avoid persisting the wrong account name into azd env.
+    $CuAccounts = @(az cognitiveservices account list -g $RESOURCE_GROUP --query "[?kind=='AIServices'].name" -o tsv 2>$null)
+    $CuAccounts = @($CuAccounts | Where-Object { $_ -and $_.Trim() -ne "" })
+    if ($CuAccounts.Count -eq 1) {
+        $CU_ACCOUNT_NAME = $CuAccounts[0]
+        Write-Host "  Discovered AIServices account in resource group: $CU_ACCOUNT_NAME"
         # Refresh the azd env so subsequent runs use the correct value.
         try { azd env set CONTENT_UNDERSTANDING_ACCOUNT_NAME $CU_ACCOUNT_NAME 2>$null | Out-Null } catch { }
+    } elseif ($CuAccounts.Count -gt 1) {
+        Write-Host "  [Warn] Multiple AIServices accounts found in resource group '$RESOURCE_GROUP': $($CuAccounts -join ', ')"
+        Write-Host "         Please set CONTENT_UNDERSTANDING_ACCOUNT_NAME in azd env to the correct account name. Skipping refresh."
+    } else {
+        Write-Host "  [Warn] No Content Understanding (AIServices) account found in resource group '$RESOURCE_GROUP'. Skipping refresh."
     }
 }
 
-if (-not $CU_ACCOUNT_NAME) {
-    Write-Host "  [Warn] No Content Understanding (AIServices) account found in resource group '$RESOURCE_GROUP'. Skipping refresh."
-} else {
+if ($CU_ACCOUNT_NAME) {
     Write-Host "  Refreshing account: $CU_ACCOUNT_NAME in resource group: $RESOURCE_GROUP"
     az cognitiveservices account update -g $RESOURCE_GROUP -n $CU_ACCOUNT_NAME --tags refresh=true --output none 2>$null
     if ($LASTEXITCODE -eq 0) {

--- a/infra/scripts/post_deployment.ps1
+++ b/infra/scripts/post_deployment.ps1
@@ -259,11 +259,21 @@ try {
 # left over from prior deployments (different template/fork) and against the env value
 # pointing to a resource that no longer exists.
 if ($CU_ACCOUNT_NAME) {
-    az cognitiveservices account show -g $RESOURCE_GROUP -n $CU_ACCOUNT_NAME --output none 2>$null
+    # Capture stderr so we can distinguish a real "not found" response from a
+    # transient/auth/CLI failure. Only treat the env value as stale when Azure
+    # actually reports the resource is missing; for any other error keep the
+    # env value untouched and log the underlying error for diagnosability.
+    $ShowOutput = az cognitiveservices account show -g $RESOURCE_GROUP -n $CU_ACCOUNT_NAME --output none 2>&1
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "  [Warn] Cognitive Services account '$CU_ACCOUNT_NAME' from azd env was not found in resource group '$RESOURCE_GROUP'."
-        Write-Host "         The azd env value may be stale. Attempting to discover the AIServices account in the resource group..."
-        $CU_ACCOUNT_NAME = ""
+        $ShowOutputStr = ($ShowOutput | Out-String).Trim()
+        if ($ShowOutputStr -match '(?i)ResourceNotFound|was not found|could not be found') {
+            Write-Host "  [Warn] Cognitive Services account '$CU_ACCOUNT_NAME' from azd env was not found in resource group '$RESOURCE_GROUP'."
+            Write-Host "         The azd env value may be stale. Attempting to discover the AIServices account in the resource group..."
+            $CU_ACCOUNT_NAME = ""
+        } else {
+            Write-Host "  [Warn] Could not verify Cognitive Services account '$CU_ACCOUNT_NAME' (transient or CLI error). Keeping env value and skipping discovery."
+            Write-Host "         az error: $ShowOutputStr"
+        }
     }
 }
 
@@ -289,10 +299,14 @@ if (-not $CU_ACCOUNT_NAME) {
 
 if ($CU_ACCOUNT_NAME) {
     Write-Host "  Refreshing account: $CU_ACCOUNT_NAME in resource group: $RESOURCE_GROUP"
-    az cognitiveservices account update -g $RESOURCE_GROUP -n $CU_ACCOUNT_NAME --tags refresh=true --output none 2>$null
+    # Capture stderr so that any Azure CLI error is preserved in deployment
+    # logs even though this refresh step is non-fatal.
+    $UpdateOutput = az cognitiveservices account update -g $RESOURCE_GROUP -n $CU_ACCOUNT_NAME --tags refresh=true --output none 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-Host "  [OK] Successfully refreshed Cognitive Services account '$CU_ACCOUNT_NAME'."
     } else {
+        $UpdateOutputStr = ($UpdateOutput | Out-String).Trim()
         Write-Host "  [Warn] Could not refresh Cognitive Services account '$CU_ACCOUNT_NAME'. Continuing - this step is non-fatal."
+        Write-Host "         az error: $UpdateOutputStr"
     }
 }

--- a/infra/scripts/post_deployment.ps1
+++ b/infra/scripts/post_deployment.ps1
@@ -239,3 +239,52 @@ if (-not $ApiReady) {
     Write-Host "  Schemas registered: $($Registered.Count)"
     Write-Host ("=" * 60)
 }
+
+# --- Refresh Content Understanding Cognitive Services account ---
+Write-Host ""
+Write-Host ("=" * 60)
+Write-Host "Refreshing Content Understanding Cognitive Services account..."
+Write-Host ("=" * 60)
+
+$CU_ACCOUNT_NAME = ""
+try {
+    $CU_ACCOUNT_NAME = (azd env get-value CONTENT_UNDERSTANDING_ACCOUNT_NAME 2>$null)
+    if (-not $CU_ACCOUNT_NAME) { $CU_ACCOUNT_NAME = "" }
+} catch {
+    $CU_ACCOUNT_NAME = ""
+}
+
+# Verify the account from the env value still exists; if not, fall back to discovering
+# the AIServices account in the resource group. This protects against stale .env values
+# left over from prior deployments (different template/fork) and against the env value
+# pointing to a resource that no longer exists.
+if ($CU_ACCOUNT_NAME) {
+    az cognitiveservices account show -g $RESOURCE_GROUP -n $CU_ACCOUNT_NAME --output none 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  [Warn] Cognitive Services account '$CU_ACCOUNT_NAME' from azd env was not found in resource group '$RESOURCE_GROUP'."
+        Write-Host "         The azd env value may be stale. Attempting to discover the AIServices account in the resource group..."
+        $CU_ACCOUNT_NAME = ""
+    }
+}
+
+if (-not $CU_ACCOUNT_NAME) {
+    $DiscoveredCuAccount = (az cognitiveservices account list -g $RESOURCE_GROUP --query "[?kind=='AIServices'].name | [0]" -o tsv 2>$null)
+    if ($DiscoveredCuAccount) {
+        Write-Host "  Discovered AIServices account in resource group: $DiscoveredCuAccount"
+        $CU_ACCOUNT_NAME = $DiscoveredCuAccount
+        # Refresh the azd env so subsequent runs use the correct value.
+        try { azd env set CONTENT_UNDERSTANDING_ACCOUNT_NAME $CU_ACCOUNT_NAME 2>$null | Out-Null } catch { }
+    }
+}
+
+if (-not $CU_ACCOUNT_NAME) {
+    Write-Host "  [Warn] No Content Understanding (AIServices) account found in resource group '$RESOURCE_GROUP'. Skipping refresh."
+} else {
+    Write-Host "  Refreshing account: $CU_ACCOUNT_NAME in resource group: $RESOURCE_GROUP"
+    az cognitiveservices account update -g $RESOURCE_GROUP -n $CU_ACCOUNT_NAME --tags refresh=true --output none 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  [OK] Successfully refreshed Cognitive Services account '$CU_ACCOUNT_NAME'."
+    } else {
+        Write-Host "  [Warn] Could not refresh Cognitive Services account '$CU_ACCOUNT_NAME'. Continuing - this step is non-fatal."
+    }
+}

--- a/infra/scripts/post_deployment.sh
+++ b/infra/scripts/post_deployment.sh
@@ -261,10 +261,29 @@ CU_ACCOUNT_NAME=$(azd env get-value CONTENT_UNDERSTANDING_ACCOUNT_NAME 2>/dev/nu
 # left over from prior deployments (different template/fork) and against the env value
 # pointing to a resource that no longer exists.
 if [ -n "$CU_ACCOUNT_NAME" ]; then
-  if ! az cognitiveservices account show -g "$RESOURCE_GROUP" -n "$CU_ACCOUNT_NAME" --output none 2>/dev/null; then
-    echo "  ⚠️ Cognitive Services account '$CU_ACCOUNT_NAME' from azd env was not found in resource group '$RESOURCE_GROUP'."
-    echo "     The azd env value may be stale. Attempting to discover the AIServices account in the resource group..."
-    CU_ACCOUNT_NAME=""
+  # Capture stderr so we can distinguish a real "not found" response from a
+  # transient/auth/CLI failure. Only treat the env value as stale when Azure
+  # actually reports the resource is missing; for any other error keep the
+  # env value untouched and log the underlying error for diagnosability.
+  # `set +e` is required because `set -e` (enabled at the top of the script)
+  # would otherwise exit the script as soon as `az ... show` returns non-zero,
+  # before we can inspect $? and decide whether to fall back to discovery.
+  set +e
+  CU_SHOW_ERR=$(az cognitiveservices account show \
+    -g "$RESOURCE_GROUP" \
+    -n "$CU_ACCOUNT_NAME" \
+    --output none 2>&1)
+  CU_SHOW_EC=$?
+  set -e
+  if [ $CU_SHOW_EC -ne 0 ]; then
+    if echo "$CU_SHOW_ERR" | grep -qiE "ResourceNotFound|was not found|could not be found"; then
+      echo "  ⚠️ Cognitive Services account '$CU_ACCOUNT_NAME' from azd env was not found in resource group '$RESOURCE_GROUP'."
+      echo "     The azd env value may be stale. Attempting to discover the AIServices account in the resource group..."
+      CU_ACCOUNT_NAME=""
+    else
+      echo "  ⚠️ Could not verify Cognitive Services account '$CU_ACCOUNT_NAME' (transient or CLI error). Keeping env value and skipping discovery."
+      echo "     az error: $CU_SHOW_ERR"
+    fi
   fi
 fi
 
@@ -273,7 +292,13 @@ if [ -z "$CU_ACCOUNT_NAME" ]; then
   # group contains exactly one we auto-recover; when it contains more than one
   # we refuse to guess and ask the user to set the env value explicitly, to
   # avoid persisting the wrong account name into azd env.
-  mapfile -t CU_ACCOUNTS < <(az cognitiveservices account list \
+  # Use a portable `while read` loop instead of `mapfile`, because `mapfile`
+  # requires bash 4+ and the azd postprovision hook also runs on macOS where
+  # the default shell is still bash 3.2.
+  CU_ACCOUNTS=()
+  while IFS= read -r _cu_acct; do
+    [ -n "$_cu_acct" ] && CU_ACCOUNTS+=("$_cu_acct")
+  done < <(az cognitiveservices account list \
     -g "$RESOURCE_GROUP" \
     --query "[?kind=='AIServices'].name" \
     -o tsv 2>/dev/null || true)
@@ -292,13 +317,23 @@ fi
 
 if [ -n "$CU_ACCOUNT_NAME" ]; then
   echo "  Refreshing account: $CU_ACCOUNT_NAME in resource group: $RESOURCE_GROUP"
-  if az cognitiveservices account update \
+  # Capture stderr so that any Azure CLI error is preserved in deployment
+  # logs even though this refresh step is non-fatal.
+  # `set +e` is required because `set -e` (enabled at the top of the script)
+  # would otherwise exit the script as soon as `az ... update` returns
+  # non-zero, defeating the explicit "non-fatal" handling below.
+  set +e
+  CU_UPDATE_ERR=$(az cognitiveservices account update \
     -g "$RESOURCE_GROUP" \
     -n "$CU_ACCOUNT_NAME" \
     --tags refresh=true \
-    --output none 2>/dev/null; then
+    --output none 2>&1)
+  CU_UPDATE_EC=$?
+  set -e
+  if [ $CU_UPDATE_EC -eq 0 ]; then
     echo "  ✅ Successfully refreshed Cognitive Services account '$CU_ACCOUNT_NAME'."
   else
     echo "  ⚠️ Could not refresh Cognitive Services account '$CU_ACCOUNT_NAME'. Continuing — this step is non-fatal."
+    echo "     az error: $CU_UPDATE_ERR"
   fi
 fi

--- a/infra/scripts/post_deployment.sh
+++ b/infra/scripts/post_deployment.sh
@@ -256,17 +256,42 @@ echo "============================================================"
 
 CU_ACCOUNT_NAME=$(azd env get-value CONTENT_UNDERSTANDING_ACCOUNT_NAME 2>/dev/null || echo "")
 
+# Verify the account from the env value still exists; if not, fall back to discovering
+# the AIServices account in the resource group. This protects against stale .env values
+# left over from prior deployments (different template/fork) and against the env value
+# pointing to a resource that no longer exists.
+if [ -n "$CU_ACCOUNT_NAME" ]; then
+  if ! az cognitiveservices account show -g "$RESOURCE_GROUP" -n "$CU_ACCOUNT_NAME" --output none 2>/dev/null; then
+    echo "  ⚠️ Cognitive Services account '$CU_ACCOUNT_NAME' from azd env was not found in resource group '$RESOURCE_GROUP'."
+    echo "     The azd env value may be stale. Attempting to discover the AIServices account in the resource group..."
+    CU_ACCOUNT_NAME=""
+  fi
+fi
+
 if [ -z "$CU_ACCOUNT_NAME" ]; then
-  echo "  ⚠️ CONTENT_UNDERSTANDING_ACCOUNT_NAME not found in azd env. Skipping refresh."
+  DISCOVERED_CU_ACCOUNT=$(az cognitiveservices account list \
+    -g "$RESOURCE_GROUP" \
+    --query "[?kind=='AIServices'].name | [0]" \
+    -o tsv 2>/dev/null || echo "")
+  if [ -n "$DISCOVERED_CU_ACCOUNT" ]; then
+    echo "  Discovered AIServices account in resource group: $DISCOVERED_CU_ACCOUNT"
+    CU_ACCOUNT_NAME="$DISCOVERED_CU_ACCOUNT"
+    # Refresh the azd env so subsequent runs use the correct value.
+    azd env set CONTENT_UNDERSTANDING_ACCOUNT_NAME "$CU_ACCOUNT_NAME" >/dev/null 2>&1 || true
+  fi
+fi
+
+if [ -z "$CU_ACCOUNT_NAME" ]; then
+  echo "  ⚠️ No Content Understanding (AIServices) account found in resource group '$RESOURCE_GROUP'. Skipping refresh."
 else
   echo "  Refreshing account: $CU_ACCOUNT_NAME in resource group: $RESOURCE_GROUP"
   if az cognitiveservices account update \
     -g "$RESOURCE_GROUP" \
     -n "$CU_ACCOUNT_NAME" \
     --tags refresh=true \
-    --output none; then
+    --output none 2>/dev/null; then
     echo "  ✅ Successfully refreshed Cognitive Services account '$CU_ACCOUNT_NAME'."
   else
-    echo "  ❌ Failed to refresh Cognitive Services account '$CU_ACCOUNT_NAME'."
+    echo "  ⚠️ Could not refresh Cognitive Services account '$CU_ACCOUNT_NAME'. Continuing — this step is non-fatal."
   fi
 fi

--- a/infra/scripts/post_deployment.sh
+++ b/infra/scripts/post_deployment.sh
@@ -269,21 +269,28 @@ if [ -n "$CU_ACCOUNT_NAME" ]; then
 fi
 
 if [ -z "$CU_ACCOUNT_NAME" ]; then
-  DISCOVERED_CU_ACCOUNT=$(az cognitiveservices account list \
+  # Enumerate ALL AIServices accounts (not just the first). When the resource
+  # group contains exactly one we auto-recover; when it contains more than one
+  # we refuse to guess and ask the user to set the env value explicitly, to
+  # avoid persisting the wrong account name into azd env.
+  mapfile -t CU_ACCOUNTS < <(az cognitiveservices account list \
     -g "$RESOURCE_GROUP" \
-    --query "[?kind=='AIServices'].name | [0]" \
-    -o tsv 2>/dev/null || echo "")
-  if [ -n "$DISCOVERED_CU_ACCOUNT" ]; then
-    echo "  Discovered AIServices account in resource group: $DISCOVERED_CU_ACCOUNT"
-    CU_ACCOUNT_NAME="$DISCOVERED_CU_ACCOUNT"
+    --query "[?kind=='AIServices'].name" \
+    -o tsv 2>/dev/null || true)
+  if [ "${#CU_ACCOUNTS[@]}" -eq 1 ]; then
+    CU_ACCOUNT_NAME="${CU_ACCOUNTS[0]}"
+    echo "  Discovered AIServices account in resource group: $CU_ACCOUNT_NAME"
     # Refresh the azd env so subsequent runs use the correct value.
     azd env set CONTENT_UNDERSTANDING_ACCOUNT_NAME "$CU_ACCOUNT_NAME" >/dev/null 2>&1 || true
+  elif [ "${#CU_ACCOUNTS[@]}" -gt 1 ]; then
+    echo "  ⚠️ Multiple AIServices accounts found in resource group '$RESOURCE_GROUP': ${CU_ACCOUNTS[*]}"
+    echo "     Please set CONTENT_UNDERSTANDING_ACCOUNT_NAME in azd env to the correct account name. Skipping refresh."
+  else
+    echo "  ⚠️ No Content Understanding (AIServices) account found in resource group '$RESOURCE_GROUP'. Skipping refresh."
   fi
 fi
 
-if [ -z "$CU_ACCOUNT_NAME" ]; then
-  echo "  ⚠️ No Content Understanding (AIServices) account found in resource group '$RESOURCE_GROUP'. Skipping refresh."
-else
+if [ -n "$CU_ACCOUNT_NAME" ]; then
   echo "  Refreshing account: $CU_ACCOUNT_NAME in resource group: $RESOURCE_GROUP"
   if az cognitiveservices account update \
     -g "$RESOURCE_GROUP" \


### PR DESCRIPTION
This pull request introduces improvements to the deployment scripts and infrastructure template for better reliability and maintainability, particularly around the handling of the Content Understanding Cognitive Services account. The most significant changes are enhancements to the post-deployment scripts to robustly detect and refresh the correct Cognitive Services account, as well as minor updates to the Bicep-generated infrastructure template.

**Deployment script improvements:**

* Both `post_deployment.ps1` and `post_deployment.sh` now verify that the `CONTENT_UNDERSTANDING_ACCOUNT_NAME` environment variable points to an existing Cognitive Services account. If not, they attempt to discover the correct `AIServices` account in the resource group and update the environment variable accordingly. This prevents issues caused by stale or missing environment values and ensures the correct account is refreshed. [[1]](diffhunk://#diff-dbeece5fe68b590b88e37ac955ffd02a51fa6a282ca985d453e99537042ae3dcR242-R290) [[2]](diffhunk://#diff-1e4234fe6522e45d116dea4a258ba6926ff3215da41eb72362329316ee0c4fb0R259-R295)

**Infrastructure template updates:**

* Updated the Bicep compiler version and template hashes throughout `infra/main.json` to reflect the latest tooling and ensure template consistency. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L340-R341) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L19309-R19310) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L23335-R23336) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L23939-R23940) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L36317-R36318) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L37577-R37578) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39310-R39311) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39464-R39465) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L39682-R39683) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L41415-R41416) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L41569-R41570)

* Minor reordering of dependencies in resource arrays within `infra/main.json` to maintain correct deployment sequencing and consistency. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L36186-R36187) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R42490-L42492)## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

