### PR TITLE
fix: Resolve CodeQL issues to avoid unsafe use of DefaultAzureCredential in python application.

### DIFF
--- a/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
+++ b/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
@@ -130,7 +130,11 @@ def get_azure_credential():
     logging.info(
         "[AUTH] All CLI credentials failed - falling back to DefaultAzureCredential"
     )
-    return DefaultAzureCredential()
+    raise RuntimeError(
+        "No Azure authentication available. "
+        "Use Managed Identity in Azure or run "
+        "'az login' / 'azd auth login' locally."
+    )
 
 
 def get_async_azure_credential():

--- a/src/ContentProcessor/src/libs/utils/credential_util.py
+++ b/src/ContentProcessor/src/libs/utils/credential_util.py
@@ -130,7 +130,11 @@ def get_azure_credential():
     logging.info(
         "[AUTH] All CLI credentials failed - falling back to DefaultAzureCredential"
     )
-    return DefaultAzureCredential()
+    raise RuntimeError(
+        "No Azure authentication available. "
+        "Use Managed Identity in Azure or run "
+        "'az login' / 'azd auth login' locally."
+    )
 
 
 def get_async_azure_credential():

--- a/src/ContentProcessorAPI/app/libs/base/application_base.py
+++ b/src/ContentProcessorAPI/app/libs/base/application_base.py
@@ -15,7 +15,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 
-from azure.identity import DefaultAzureCredential
+from app.utils.azure_credential_utils import get_azure_credential
 from dotenv import load_dotenv
 
 from app.libs.application.application_configuration import (
@@ -72,7 +72,7 @@ class Application_Base(ABC):
         self._load_env(env_file_path=env_file_path)
 
         self.application_context = AppContext()
-        self.application_context.set_credential(DefaultAzureCredential())
+        self.application_context.set_credential(get_azure_credential())
 
         app_config_endpoint: str | None = EnvConfiguration().app_config_endpoint
         if app_config_endpoint != "" and app_config_endpoint is not None:

--- a/src/ContentProcessorWorkflow/src/libs/azure/app_configuration.py
+++ b/src/ContentProcessorWorkflow/src/libs/azure/app_configuration.py
@@ -91,7 +91,13 @@ class AppConfigurationHelper:
             ValueError: If *app_configuration_url* is ``None`` or the
                 credential is missing after defaulting.
         """
-        self.credential = credential or DefaultAzureCredential()
+        if credential is None:
+            raise ValueError(
+                "Azure credential is required. "
+                "Use Managed Identity, AzureCliCredential, or AzureDeveloperCliCredential."
+            )
+
+        self.credential = credential
         self.app_config_endpoint = app_configuration_url
         self._initialize_client()
 

--- a/src/ContentProcessorWorkflow/src/libs/base/application_base.py
+++ b/src/ContentProcessorWorkflow/src/libs/base/application_base.py
@@ -36,6 +36,7 @@ import os
 from abc import ABC, abstractmethod
 
 from azure.identity import DefaultAzureCredential
+from utils.credential_util import get_azure_credential
 from src.utils.credential_util import get_azure_credential
 from dotenv import load_dotenv
 

--- a/src/ContentProcessorWorkflow/src/libs/base/application_base.py
+++ b/src/ContentProcessorWorkflow/src/libs/base/application_base.py
@@ -36,6 +36,7 @@ import os
 from abc import ABC, abstractmethod
 
 from azure.identity import DefaultAzureCredential
+from src.utils.credential_util import get_azure_credential
 from dotenv import load_dotenv
 
 from libs.agent_framework.agent_framework_settings import AgentFrameworkSettings
@@ -117,7 +118,7 @@ class ApplicationBase(ABC):
         self._load_env(env_file_path=env_file_path)
 
         self.application_context = AppContext()
-        self.application_context.set_credential(DefaultAzureCredential())
+        self.application_context.set_credential(get_azure_credential())
 
         app_config_url: str | None = _envConfiguration().app_config_endpoint
         if app_config_url != "" and app_config_url is not None:

--- a/src/ContentProcessorWorkflow/src/libs/base/application_base.py
+++ b/src/ContentProcessorWorkflow/src/libs/base/application_base.py
@@ -37,7 +37,6 @@ from abc import ABC, abstractmethod
 
 from azure.identity import DefaultAzureCredential
 from utils.credential_util import get_azure_credential
-from src.utils.credential_util import get_azure_credential
 from dotenv import load_dotenv
 
 from libs.agent_framework.agent_framework_settings import AgentFrameworkSettings

--- a/src/ContentProcessorWorkflow/src/libs/base/application_base.py
+++ b/src/ContentProcessorWorkflow/src/libs/base/application_base.py
@@ -35,7 +35,6 @@ import logging
 import os
 from abc import ABC, abstractmethod
 
-from azure.identity import DefaultAzureCredential
 from utils.credential_util import get_azure_credential
 from dotenv import load_dotenv
 

--- a/src/ContentProcessorWorkflow/src/utils/credential_util.py
+++ b/src/ContentProcessorWorkflow/src/utils/credential_util.py
@@ -126,7 +126,12 @@ def get_azure_credential():
     logging.info(
         "[AUTH] All CLI credentials failed - falling back to DefaultAzureCredential"
     )
-    return DefaultAzureCredential()
+    
+    raise RuntimeError(
+    "No Azure authentication available. "
+    "Use Managed Identity in Azure or run "
+    "'az login' / 'azd auth login' locally."
+    )
 
 
 def get_async_azure_credential():

--- a/src/tests/ContentProcessor/utils/test_azure_credential_utils.py
+++ b/src/tests/ContentProcessor/utils/test_azure_credential_utils.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import libs.utils.azure_credential_utils as azure_credential_utils
 
 MODULE = "libs.utils.azure_credential_utils"
@@ -45,16 +47,16 @@ class TestGetAzureCredential:
         mock_managed.assert_called_once_with(client_id="test-client-id")
         assert credential == mock_instance
 
-    @patch(f"{MODULE}.DefaultAzureCredential")
     @patch(f"{MODULE}.AzureDeveloperCliCredential", side_effect=Exception("no azd"))
     @patch(f"{MODULE}.AzureCliCredential", side_effect=Exception("no az"))
     @patch.dict("os.environ", {}, clear=True)
-    def test_falls_back_to_default(self, mock_cli, mock_dev_cli, mock_default):
-        mock_instance = MagicMock()
-        mock_default.return_value = mock_instance
-        credential = azure_credential_utils.get_azure_credential()
-        mock_default.assert_called_once()
-        assert credential == mock_instance
+    def test_raises_when_no_credentials_available(
+        self, mock_cli, mock_dev_cli
+    ):
+        with pytest.raises(RuntimeError) as exc:
+            azure_credential_utils.get_azure_credential()
+
+        assert "No Azure authentication available" in str(exc.value)
 
 
 # ── TestGetAsyncAzureCredential ─────────────────────────────────────────

--- a/src/tests/ContentProcessor/utils/test_azure_credential_utils_extended.py
+++ b/src/tests/ContentProcessor/utils/test_azure_credential_utils_extended.py
@@ -42,26 +42,22 @@ class TestAzureCredentialUtilsExtended:
             assert credential == mock_instance
 
     def test_get_azure_credential_cli_failure_fallback(self, monkeypatch):
-        """Test fallback to DefaultAzureCredential when CLI credentials fail"""
+        """Test RuntimeError when all credential options fail"""
         # Clear all Azure environment indicators
         for key in ["WEBSITE_SITE_NAME", "AZURE_CLIENT_ID", "MSI_ENDPOINT",
                     "IDENTITY_ENDPOINT", "KUBERNETES_SERVICE_HOST", "CONTAINER_REGISTRY_LOGIN"]:
             monkeypatch.delenv(key, raising=False)
 
         with patch('libs.utils.azure_credential_utils.AzureCliCredential') as mock_cli_cred, \
-             patch('libs.utils.azure_credential_utils.AzureDeveloperCliCredential') as mock_azd_cred, \
-             patch('libs.utils.azure_credential_utils.DefaultAzureCredential') as mock_default:
+             patch('libs.utils.azure_credential_utils.AzureDeveloperCliCredential') as mock_azd_cred:
 
-            # Make both CLI credentials raise exceptions
             mock_cli_cred.side_effect = Exception("CLI credential failed")
             mock_azd_cred.side_effect = Exception("AZD credential failed")
-            mock_default_instance = Mock()
-            mock_default.return_value = mock_default_instance
 
-            credential = get_azure_credential()
+            with pytest.raises(RuntimeError) as exc:
+                get_azure_credential()
 
-            assert credential == mock_default_instance
-            mock_default.assert_called_once()
+            assert "No Azure authentication available" in str(exc.value)
 
     def test_get_azure_credential_azd_success(self, monkeypatch):
         """Test successful Azure Developer CLI credential"""

--- a/src/tests/ContentProcessorWorkflow/utils/test_credential_util_extended.py
+++ b/src/tests/ContentProcessorWorkflow/utils/test_credential_util_extended.py
@@ -1,5 +1,6 @@
 """Extended tests for credential_util.py to improve coverage"""
 from unittest.mock import Mock, patch
+import pytest
 from utils.credential_util import (
     get_azure_credential,
     get_async_azure_credential,
@@ -40,24 +41,27 @@ class TestCredentialUtilExtended:
             assert credential == mock_instance
 
     def test_get_azure_credential_all_cli_fail(self, monkeypatch):
-        """Test fallback when all CLI credentials fail"""
-        for key in ["WEBSITE_SITE_NAME", "AZURE_CLIENT_ID", "MSI_ENDPOINT",
-                    "IDENTITY_ENDPOINT", "KUBERNETES_SERVICE_HOST", "CONTAINER_REGISTRY_LOGIN"]:
+        """Test RuntimeError when all credential options fail"""
+        for key in [
+            "WEBSITE_SITE_NAME",
+            "AZURE_CLIENT_ID",
+            "MSI_ENDPOINT",
+            "IDENTITY_ENDPOINT",
+            "KUBERNETES_SERVICE_HOST",
+            "CONTAINER_REGISTRY_LOGIN",
+        ]:
             monkeypatch.delenv(key, raising=False)
 
         with patch('utils.credential_util.AzureCliCredential') as mock_cli, \
-             patch('utils.credential_util.AzureDeveloperCliCredential') as mock_azd, \
-             patch('utils.credential_util.DefaultAzureCredential') as mock_default:
+             patch('utils.credential_util.AzureDeveloperCliCredential') as mock_azd:
 
             mock_cli.side_effect = Exception("AzureCLI not available")
             mock_azd.side_effect = Exception("AzureDeveloperCLI not available")
-            mock_default_instance = Mock()
-            mock_default.return_value = mock_default_instance
 
-            credential = get_azure_credential()
+            with pytest.raises(RuntimeError) as exc:
+                get_azure_credential()
 
-            assert credential == mock_default_instance
-            mock_default.assert_called_once()
+            assert "No Azure authentication available" in str(exc.value)
 
     def test_get_azure_credential_cli_success(self, monkeypatch):
         """Test successful Azure CLI credential"""


### PR DESCRIPTION
## Purpose
<img width="747" height="423" alt="image" src="https://github.com/user-attachments/assets/96ceacde-0173-475e-bf3e-82a095064db7" />


Resolved CodeQL issues as shown in the screenshot to avoid unsafe use of DefaultAzureCredential in python application. DefaultAzureCredential should only be used for local development and testing purposes. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

