### PR TITLE
ci: Refactor Docker workflow

### DIFF
--- a/.github/workflows/deploy-orchestrator.yml
+++ b/.github/workflows/deploy-orchestrator.yml
@@ -72,10 +72,8 @@ env:
 
 jobs:
   docker-build:
+    if: inputs.trigger_type == 'workflow_dispatch' && inputs.build_docker_image == true
     uses: ./.github/workflows/job-docker-build.yml
-    with:
-      trigger_type: ${{ inputs.trigger_type }}
-      build_docker_image: ${{ inputs.build_docker_image }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/job-deploy-linux.yml
+++ b/.github/workflows/job-deploy-linux.yml
@@ -266,7 +266,7 @@ jobs:
           azd env set AZURE_ENV_IMAGETAG="$IMAGE_TAG"
 
           if [[ "$BUILD_DOCKER_IMAGE" == "true" ]]; then
-            ACR_NAME=$(echo "${{ secrets.ACR_TEST_LOGIN_SERVER }}")
+            ACR_NAME=$(echo "${{ vars.ACR_TEST_LOGIN_SERVER }}")
             azd env set AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT="$ACR_NAME"
             echo "Set ACR name to: $ACR_NAME"
           else

--- a/.github/workflows/job-deploy-windows.yml
+++ b/.github/workflows/job-deploy-windows.yml
@@ -265,7 +265,7 @@ jobs:
           # Set ACR name only when building Docker image
           if ($env:BUILD_DOCKER_IMAGE -eq "true") {
             # Extract ACR name from login server and set as environment variable
-            $ACR_NAME = "${{ secrets.ACR_TEST_LOGIN_SERVER }}"
+            $ACR_NAME = "${{ vars.ACR_TEST_LOGIN_SERVER }}"
             azd env set AZURE_ENV_CONTAINER_REGISTRY_ENDPOINT="$ACR_NAME"
             Write-Host "Set ACR name to: $ACR_NAME"
           } else {

--- a/.github/workflows/job-docker-build.yml
+++ b/.github/workflows/job-docker-build.yml
@@ -1,28 +1,22 @@
-name: Docker Build Job
+name: Build & Push Test Images (Feature Branch)
 
 on:
   workflow_call:
-    inputs:
-      trigger_type:
-        description: 'Trigger type (workflow_dispatch, pull_request, schedule)'
-        required: true
-        type: string
-      build_docker_image:
-        description: 'Build And Push Docker Image (Optional)'
-        required: false
-        default: false
-        type: boolean
     outputs:
       IMAGE_TAG:
         description: "Generated Docker Image Tag"
         value: ${{ jobs.docker-build.outputs.IMAGE_TAG }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
 
 env:
   BRANCH_NAME: ${{ github.event.workflow_run.head_branch || github.head_ref || github.ref_name }}
 
 jobs:
   docker-build:
-    if: inputs.trigger_type == 'workflow_dispatch' && inputs.build_docker_image == true
     runs-on: ubuntu-latest
     environment: production
     outputs:
@@ -56,7 +50,11 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Log in to Azure Container Registry
-        run: az acr login --name ${{ secrets.ACR_TEST_LOGIN_SERVER }}
+        shell: bash
+        run: |
+          # Extract registry name from login server (e.g., myacr.azurecr.io -> myacr)
+          ACR_NAME=$(echo "${{ vars.ACR_TEST_LOGIN_SERVER }}" | cut -d'.' -f1)
+          az acr login --name "$ACR_NAME"
 
       - name: Build and Push ContentProcessor Docker image
         uses: docker/build-push-action@v7
@@ -67,8 +65,8 @@ jobs:
           file: ./src/ContentProcessor/Dockerfile
           push: true
           tags: |
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessor:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessor:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessor:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessor:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
 
       - name: Build and Push ContentProcessorAPI Docker image
         uses: docker/build-push-action@v7
@@ -79,8 +77,8 @@ jobs:
           file: ./src/ContentProcessorAPI/Dockerfile
           push: true
           tags: |
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessorapi:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessorapi:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessorapi:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessorapi:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
 
       - name: Build and Push ContentProcessorWeb Docker image
         uses: docker/build-push-action@v7
@@ -91,8 +89,8 @@ jobs:
           file: ./src/ContentProcessorWeb/Dockerfile
           push: true
           tags: |
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessorweb:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessorweb:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessorweb:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessorweb:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
 
       - name: Build and Push ContentProcessorWorkflow Docker image
         uses: docker/build-push-action@v6
@@ -103,8 +101,8 @@ jobs:
           file: ./src/ContentProcessorWorkflow/Dockerfile
           push: true
           tags: |
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessorworkflow:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
-            ${{ secrets.ACR_TEST_LOGIN_SERVER }}/contentprocessorworkflow:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessorworkflow:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}
+            ${{ vars.ACR_TEST_LOGIN_SERVER }}/contentprocessorworkflow:${{ steps.generate_docker_tag.outputs.IMAGE_TAG }}_${{ github.run_number }}
 
       - name: Verify Docker Image Build
         shell: bash
@@ -116,7 +114,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          ACR_NAME=$(echo "${{ secrets.ACR_TEST_LOGIN_SERVER }}")
+          ACR_NAME=$(echo "${{ vars.ACR_TEST_LOGIN_SERVER }}")
           echo "## 🐳 Docker Build Job Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Purpose
This pull request updates the GitHub Actions workflows to improve how Azure Container Registry (ACR) credentials are managed and referenced. The main focus is to replace the use of secrets with repository variables for the ACR login server, streamline Docker image tagging, and clarify workflow triggers. These changes enhance security, maintainability, and consistency across deployment workflows.

**Azure Container Registry (ACR) Reference Updates:**

* Replaced all references to `secrets.ACR_TEST_LOGIN_SERVER` with `vars.ACR_TEST_LOGIN_SERVER` in Docker build and deployment workflows, ensuring that the ACR login server is now sourced from repository variables instead of secrets. This affects image tagging, Docker login commands, and build summaries. [[1]](diffhunk://#diff-0602978fc8fc7dd24cfa7aa076b45f9264d4c0c574d8bf0b66434835968420b5L269-R269) [[2]](diffhunk://#diff-4c3acc8de63274ed8be3d7d9c1f2f6cf9b86e46e7e3079889973be9eb760adbdL268-R268) [[3]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL59-R57) [[4]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL70-R69) [[5]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL82-R81) [[6]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL94-R93) [[7]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL106-R105) [[8]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL119-R117)

**Workflow Trigger and Input Simplification:**

* Removed unused workflow inputs (`trigger_type`, `build_docker_image`) from `job-docker-build.yml`, and updated the workflow to use `workflow_dispatch` directly for triggering builds. [[1]](diffhunk://#diff-7a1325c1d61f8a07c01785b042fadd058c8537346016a633131604be9ef395edL1-L25) [[2]](diffhunk://#diff-d13e946b411762697bc3a5825b5350445fa0296d5c1b1489776f7b82a84dfca4R75-L78)

**Job Control and Permissions:**

* Added explicit permissions (`contents: read`, `id-token: write`) to the Docker build workflow for improved security and clarity.

These changes collectively make the CI/CD process more robust and easier to maintain by standardizing on repository variables and simplifying workflow configuration.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

