### PR TITLE
fix: downgrade agent-framework to version 1.3.0 in pyproject.toml and uv.lock

### DIFF
--- a/src/ContentProcessorWorkflow/pyproject.toml
+++ b/src/ContentProcessorWorkflow/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "agent-framework==1.3.0",
+    "agent-framework-orchestrations==1.0.0b260423",
     "aiohttp==3.14.1",
     "art==6.5",
     "azure-ai-agents==1.2.0b5",

--- a/src/ContentProcessorWorkflow/pyproject.toml
+++ b/src/ContentProcessorWorkflow/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "agent-framework==1.9.0",
+    "agent-framework==1.3.0",
     "aiohttp==3.14.1",
     "art==6.5",
     "azure-ai-agents==1.2.0b5",

--- a/src/ContentProcessorWorkflow/uv.lock
+++ b/src/ContentProcessorWorkflow/uv.lock
@@ -3200,6 +3200,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "agent-framework" },
+    { name = "agent-framework-orchestrations" },
     { name = "aiohttp" },
     { name = "art" },
     { name = "authlib" },
@@ -3242,6 +3243,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agent-framework", specifier = "==1.3.0" },
+    { name = "agent-framework-orchestrations", specifier = "==1.0.0b260423" },
     { name = "aiohttp", specifier = "==3.14.1" },
     { name = "art", specifier = "==6.5" },
     { name = "authlib", specifier = "==1.6.12" },

--- a/src/ContentProcessorWorkflow/uv.lock
+++ b/src/ContentProcessorWorkflow/uv.lock
@@ -56,14 +56,14 @@ wheels = [
 
 [[package]]
 name = "agent-framework"
-version = "1.9.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-framework-core", extra = ["all"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/06/9f5c6736f1fd449d719bb17afa0ab246cc53cbccca2befa2416cd48b1e1b/agent_framework-1.9.0.tar.gz", hash = "sha256:a8970f47ddbfb1ee823529c972b274b820f1bcaf5c79b5ef45ac0d081c1f07e1", size = 5702648, upload-time = "2026-06-18T09:42:53.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/e8/c2ee1c4dae4a86b95091969426d11361232a0c554124ba321852a6b6b9bd/agent_framework-1.3.0.tar.gz", hash = "sha256:a13423aceaf587cf28180138151d445bd2d4ce82908cef4a6fbb85fa1771bac1", size = 5509571, upload-time = "2026-05-08T00:09:16.022Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/b6/aa90a8187af2f8fc1cb55143e2b39d2a93c04a6928b4901c8832992bdcf6/agent_framework-1.9.0-py3-none-any.whl", hash = "sha256:3b0778b3995d6cfcedc4d9d8bd612b625cf52bcbbe7704a9498abde9d9989f26", size = 5686, upload-time = "2026-06-18T09:42:55.454Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/050f8f8bce8c629a88197837b4beb35cb287f880789fc01923fd5938f142/agent_framework-1.3.0-py3-none-any.whl", hash = "sha256:baaaa932639c87be99d43333f612c3b4112d6d976f0e1e72238e42a4bd572438", size = 5684, upload-time = "2026-05-08T00:09:54.064Z" },
 ]
 
 [[package]]
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "agent-framework-core"
-version = "1.9.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -233,9 +233,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/38/5b4f1f69cfe62ecf0b66838a09d82678dfc0a90084e16b3f1c0f52aa53c3/agent_framework_core-1.9.0.tar.gz", hash = "sha256:09c5f18a43209f6db53dfe0da25d3dfbf1e5176a930a8ec3859091687d8f80a2", size = 449168, upload-time = "2026-06-18T09:42:48.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/59/4c212abdb93074677d643e31a3c21e33ff26a3ccc351145475cd1ffffad7/agent_framework_core-1.3.0.tar.gz", hash = "sha256:91c3659718b733f70dde6fb3626edb044733e0f7aa5f9726c9774e17fae328ef", size = 365395, upload-time = "2026-05-08T00:09:09.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/4b/1c0140cfbb134c51d335274948bcbdcee837a3bdad86bea92ef6b7235d13/agent_framework_core-1.9.0-py3-none-any.whl", hash = "sha256:aa33c588ec839dc7fc8e4768f4ff3d3cd44d4b38d7aa9733f5ee0a37ff4de956", size = 496431, upload-time = "2026-06-18T09:42:46.613Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f2/c4258333f2691ee10869bf72f51d423808962ccf0c195b1f893c06c348ad/agent_framework_core-1.3.0-py3-none-any.whl", hash = "sha256:b7a5baf2beb383e9042af057df79dae4fda0b836cbc8530b3b2a57a3c12bb7ac", size = 407978, upload-time = "2026-05-08T00:09:32.752Z" },
 ]
 
 [package.optional-dependencies]
@@ -3241,7 +3241,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework", specifier = "==1.9.0" },
+    { name = "agent-framework", specifier = "==1.3.0" },
     { name = "aiohttp", specifier = "==3.14.1" },
     { name = "art", specifier = "==6.5" },
     { name = "authlib", specifier = "==1.6.12" },


### PR DESCRIPTION
## Purpose

This pull request makes a single change to the `pyproject.toml` file, downgrading the `agent-framework` dependency from version 1.9.0 to 1.3.0. This change may be necessary for compatibility or stability reasons.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

