### PR TITLE
chore: Update RBAC Configuration to Reference Role IDs (follow-up)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -592,7 +592,7 @@ module avmContainerRegistry 'modules/container-registry.bicep' = {
     roleAssignments: [
       {
         principalId: avmContainerRegistryReader.outputs.principalId
-        roleDefinitionIdOrName: 'AcrPull'
+        roleDefinitionIdOrName: '7f951dda-4ed3-4680-a7ca-43fe172d538d' //'AcrPull'
         principalType: 'ServicePrincipal'
       }
     ]
@@ -620,36 +620,36 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.32.0' = {
     roleAssignments: [
       {
         principalId: avmManagedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
@@ -729,32 +729,32 @@ module avmAiServices 'modules/account/aifoundry.bicep' = {
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
         principalType: 'ServicePrincipal'
       }
     ]
@@ -1316,22 +1316,22 @@ module avmAppConfig 'br/public:avm/res/app-configuration/configuration-store:0.9
     roleAssignments: [
       {
         principalId: avmContainerApp.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_API.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Web.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
     ]

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -592,7 +592,7 @@ module avmContainerRegistry 'modules/container-registry.bicep' = {
     roleAssignments: [
       {
         principalId: avmContainerRegistryReader.outputs.principalId
-        roleDefinitionIdOrName: '7f951dda-4ed3-4680-a7ca-43fe172d538d' //'AcrPull'
+        roleDefinitionIdOrName: '7f951dda-4ed3-4680-a7ca-43fe172d538d' // AcrPull
         principalType: 'ServicePrincipal'
       }
     ]
@@ -620,36 +620,36 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.32.0' = {
     roleAssignments: [
       {
         principalId: avmManagedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
@@ -729,32 +729,32 @@ module avmAiServices 'modules/account/aifoundry.bicep' = {
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' // Cognitive Services OpenAI User
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' // Azure AI Developer
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' // Cognitive Services OpenAI User
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' // Azure AI Developer
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services User
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services User
         principalType: 'ServicePrincipal'
       }
     ]
@@ -1316,22 +1316,22 @@ module avmAppConfig 'br/public:avm/res/app-configuration/configuration-store:0.9
     roleAssignments: [
       {
         principalId: avmContainerApp.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_API.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Web.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
     ]

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "3841741921827855283"
+      "templateHash": "10450741366794216818"
     },
     "name": "Content Processing Solution Accelerator",
     "description": "Bicep template to deploy the Content Processing Solution Accelerator with AVM compliance."
@@ -23908,7 +23908,7 @@
             "value": [
               {
                 "principalId": "[reference('avmContainerRegistryReader').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "AcrPull",
+                "roleDefinitionIdOrName": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
                 "principalType": "ServicePrincipal"
               }
             ]
@@ -28013,36 +28013,36 @@
             "value": [
               {
                 "principalId": "[reference('avmManagedIdentity').outputs.principalId.value]",
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "roleDefinitionIdOrName": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "roleDefinitionIdOrName": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
                 "principalId": "[reference('avmContainerApp').outputs.systemAssignedMIPrincipalId.value]",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "roleDefinitionIdOrName": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
                 "principalId": "[reference('avmContainerApp_API').outputs.systemAssignedMIPrincipalId.value]",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Queue Data Contributor",
+                "roleDefinitionIdOrName": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
                 "principalId": "[reference('avmContainerApp').outputs.systemAssignedMIPrincipalId.value]",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Queue Data Contributor",
+                "roleDefinitionIdOrName": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
                 "principalId": "[reference('avmContainerApp_API').outputs.systemAssignedMIPrincipalId.value]",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Blob Data Contributor",
+                "roleDefinitionIdOrName": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
                 "principalId": "[reference('avmContainerApp_Workflow').outputs.systemAssignedMIPrincipalId.value]",
                 "principalType": "ServicePrincipal"
               },
               {
-                "roleDefinitionIdOrName": "Storage Queue Data Contributor",
+                "roleDefinitionIdOrName": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
                 "principalId": "[reference('avmContainerApp_Workflow').outputs.systemAssignedMIPrincipalId.value]",
                 "principalType": "ServicePrincipal"
               }
@@ -36185,8 +36185,8 @@
         "avmContainerApp_API",
         "avmContainerApp_Workflow",
         "avmManagedIdentity",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageQueue)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').storageBlob)]",
         "virtualNetwork"
       ]
     },
@@ -36248,32 +36248,32 @@
               },
               {
                 "principalId": "[reference('avmContainerApp').outputs.systemAssignedMIPrincipalId.value]",
-                "roleDefinitionIdOrName": "Cognitive Services OpenAI User",
+                "roleDefinitionIdOrName": "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('avmContainerApp').outputs.systemAssignedMIPrincipalId.value]",
-                "roleDefinitionIdOrName": "Azure AI Developer",
+                "roleDefinitionIdOrName": "64702f94-c441-49e6-a78b-ef80e0188fee",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('avmContainerApp_Workflow').outputs.systemAssignedMIPrincipalId.value]",
-                "roleDefinitionIdOrName": "Cognitive Services OpenAI User",
+                "roleDefinitionIdOrName": "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('avmContainerApp_Workflow').outputs.systemAssignedMIPrincipalId.value]",
-                "roleDefinitionIdOrName": "Azure AI Developer",
+                "roleDefinitionIdOrName": "64702f94-c441-49e6-a78b-ef80e0188fee",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('avmContainerApp').outputs.systemAssignedMIPrincipalId.value]",
-                "roleDefinitionIdOrName": "Cognitive Services User",
+                "roleDefinitionIdOrName": "a97b65f3-24c7-4388-baec-2e87135dc908",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[reference('avmContainerApp_Workflow').outputs.systemAssignedMIPrincipalId.value]",
-                "roleDefinitionIdOrName": "Cognitive Services User",
+                "roleDefinitionIdOrName": "a97b65f3-24c7-4388-baec-2e87135dc908",
                 "principalType": "ServicePrincipal"
               }
             ]
@@ -56778,22 +56778,22 @@
             "value": [
               {
                 "principalId": "[tryGet(tryGet(reference('avmContainerApp').outputs, 'systemAssignedMIPrincipalId'), 'value')]",
-                "roleDefinitionIdOrName": "App Configuration Data Reader",
+                "roleDefinitionIdOrName": "516239f1-63e1-4d78-a4de-a74fb236a071",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[tryGet(tryGet(reference('avmContainerApp_API').outputs, 'systemAssignedMIPrincipalId'), 'value')]",
-                "roleDefinitionIdOrName": "App Configuration Data Reader",
+                "roleDefinitionIdOrName": "516239f1-63e1-4d78-a4de-a74fb236a071",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[tryGet(tryGet(reference('avmContainerApp_Web').outputs, 'systemAssignedMIPrincipalId'), 'value')]",
-                "roleDefinitionIdOrName": "App Configuration Data Reader",
+                "roleDefinitionIdOrName": "516239f1-63e1-4d78-a4de-a74fb236a071",
                 "principalType": "ServicePrincipal"
               },
               {
                 "principalId": "[tryGet(tryGet(reference('avmContainerApp_Workflow').outputs, 'systemAssignedMIPrincipalId'), 'value')]",
-                "roleDefinitionIdOrName": "App Configuration Data Reader",
+                "roleDefinitionIdOrName": "516239f1-63e1-4d78-a4de-a74fb236a071",
                 "principalType": "ServicePrincipal"
               }
             ]

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -595,7 +595,7 @@ module avmContainerRegistry 'modules/container-registry.bicep' = {
     roleAssignments: [
       {
         principalId: avmContainerRegistryReader.outputs.principalId
-        roleDefinitionIdOrName: '7f951dda-4ed3-4680-a7ca-43fe172d538d' //'AcrPull'
+        roleDefinitionIdOrName: '7f951dda-4ed3-4680-a7ca-43fe172d538d' // AcrPull
         principalType: 'ServicePrincipal'
       }
     ]
@@ -623,36 +623,36 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.32.0' = {
     roleAssignments: [
       {
         principalId: avmManagedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
@@ -732,32 +732,32 @@ module avmAiServices 'modules/account/aifoundry.bicep' = {
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' // Cognitive Services OpenAI User
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' // Azure AI Developer
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' // Cognitive Services OpenAI User
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' // Azure AI Developer
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services User
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' // Cognitive Services User
         principalType: 'ServicePrincipal'
       }
     ]
@@ -1340,22 +1340,22 @@ module avmAppConfig 'br/public:avm/res/app-configuration/configuration-store:0.9
     roleAssignments: [
       {
         principalId: avmContainerApp.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_API.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Web.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' // App Configuration Data Reader
         principalType: 'ServicePrincipal'
       }
     ]

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -647,7 +647,7 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.32.0' = {
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -595,7 +595,7 @@ module avmContainerRegistry 'modules/container-registry.bicep' = {
     roleAssignments: [
       {
         principalId: avmContainerRegistryReader.outputs.principalId
-        roleDefinitionIdOrName: 'AcrPull'
+        roleDefinitionIdOrName: '7f951dda-4ed3-4680-a7ca-43fe172d538d' //'AcrPull'
         principalType: 'ServicePrincipal'
       }
     ]
@@ -623,26 +623,26 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.32.0' = {
     roleAssignments: [
       {
         principalId: avmManagedIdentity.outputs.principalId
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+        roleDefinitionIdOrName: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe' //'Storage Blob Data Contributor'
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: avmContainerApp_API.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
@@ -652,7 +652,7 @@ module avmStorageAccount 'br/public:avm/res/storage/storage-account:0.32.0' = {
         principalType: 'ServicePrincipal'
       }
       {
-        roleDefinitionIdOrName: 'Storage Queue Data Contributor'
+        roleDefinitionIdOrName: '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //'Storage Queue Data Contributor'
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
         principalType: 'ServicePrincipal'
       }
@@ -732,32 +732,32 @@ module avmAiServices 'modules/account/aifoundry.bicep' = {
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services OpenAI User'
+        roleDefinitionIdOrName: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd' //'Cognitive Services OpenAI User'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Azure AI Developer'
+        roleDefinitionIdOrName: '64702f94-c441-49e6-a78b-ef80e0188fee' //'Azure AI Developer'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'Cognitive Services User'
+        roleDefinitionIdOrName: 'a97b65f3-24c7-4388-baec-2e87135dc908' //'Cognitive Services User'
         principalType: 'ServicePrincipal'
       }
     ]
@@ -1340,22 +1340,22 @@ module avmAppConfig 'br/public:avm/res/app-configuration/configuration-store:0.9
     roleAssignments: [
       {
         principalId: avmContainerApp.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_API.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Web.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
       {
         principalId: avmContainerApp_Workflow.outputs.?systemAssignedMIPrincipalId!
-        roleDefinitionIdOrName: 'App Configuration Data Reader'
+        roleDefinitionIdOrName: '516239f1-63e1-4d78-a4de-a74fb236a071' //'App Configuration Data Reader'
         principalType: 'ServicePrincipal'
       }
     ]


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Update the RBAC configuration so that every role assignment references its Azure built-in role **definition ID (GUID)** instead of the role display name. Referencing roles by GUID avoids ambiguity and intermittent lookup/deployment failures that can occur when resolving roles by display name.

Scope of changes:
* `infra/main.bicep` — convert all `roleDefinitionIdOrName` role-name values to their role definition GUIDs, each annotated with an inline `// Role Name` comment.
* `infra/main_custom.bicep` — same conversion, including the previously missed `Storage Blob Data Contributor` assignment for the workflow managed identity (flagged in review).
* Inline role-name comments use the `// Role Name` format (space after `//`, no quotes) for readability and consistency with the rest of the files.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* Every `roleDefinitionIdOrName` across the `infra` Bicep files references a role definition GUID (no remaining display-name references).
* Each GUID maps to the correct Azure built-in role (see the inline `// Role Name` comments).
* The workflow managed identity's `Storage Blob Data Contributor` assignment now uses GUID `ba92f5b4-2d11-453d-a403-e96b0029c9fe`.

## Other Information

<!-- Add any other helpful information that may be needed here. -->
Companion change to the Container Migration Solution Accelerator PR applying the same role-ID convention.
