### PR TITLE
chore: Dev to Main

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -560,7 +560,6 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2025-04-01' = {
       Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
       DeploymentName: deployment().name
-      SecurityControl: 'Ignore'
     }
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -560,6 +560,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2025-04-01' = {
       Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
       DeploymentName: deployment().name
+      SecurityControl: 'Ignore'
     }
   }
 }

--- a/infra/scripts/post_deployment.ps1
+++ b/infra/scripts/post_deployment.ps1
@@ -318,8 +318,10 @@ Write-Host ""
 Write-Host "Granting Container Apps Contributor to the deploying user on the resource group..."
 
 $DeployerObjectId = az ad signed-in-user show --query id -o tsv 2>$null
-if (-not $DeployerObjectId -or -not $RESOURCE_GROUP) {
-    Write-Host "  [Warn] Missing signed-in user id or resource group. Skipping role assignment."
+# azd env may not populate AZURE_SUBSCRIPTION_ID in every shell; fall back to the CLI context.
+if (-not $SUBSCRIPTION_ID) { $SUBSCRIPTION_ID = az account show --query id -o tsv 2>$null }
+if (-not $DeployerObjectId -or -not $SUBSCRIPTION_ID -or -not $RESOURCE_GROUP) {
+    Write-Host "  [Warn] Missing signed-in user id, subscription id, or resource group. Skipping role assignment."
 } else {
     $RgScope = "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
     $RoleOutput = az role assignment create --assignee-object-id $DeployerObjectId --assignee-principal-type User `

--- a/infra/scripts/post_deployment.ps1
+++ b/infra/scripts/post_deployment.ps1
@@ -310,3 +310,23 @@ if ($CU_ACCOUNT_NAME) {
         Write-Host "         az error: $UpdateOutputStr"
     }
 }
+
+# --- Grant the deploying user Container Apps Contributor on the resource group ---
+# Direct (non-group) User assignment so Easy Auth's on-behalf listSecrets validation
+# can resolve RBAC when the Microsoft identity provider is added (avoids group token-overage).
+Write-Host ""
+Write-Host "Granting Container Apps Contributor to the deploying user on the resource group..."
+
+$DeployerObjectId = az ad signed-in-user show --query id -o tsv 2>$null
+if (-not $DeployerObjectId -or -not $RESOURCE_GROUP) {
+    Write-Host "  [Warn] Missing signed-in user id or resource group. Skipping role assignment."
+} else {
+    $RgScope = "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
+    $RoleOutput = az role assignment create --assignee-object-id $DeployerObjectId --assignee-principal-type User `
+        --role "358470bc-b998-42bd-ab17-a7e34c199c0f" --scope $RgScope --output none 2>&1
+    if ($LASTEXITCODE -eq 0 -or ($RoleOutput | Out-String) -match '(?i)RoleAssignmentExists|already exists') {
+        Write-Host "  [OK] Container Apps Contributor granted to the deploying user."
+    } else {
+        Write-Host "  [Warn] Could not create the role assignment (non-fatal). az error: $(($RoleOutput | Out-String).Trim())"
+    }
+}

--- a/infra/scripts/post_deployment.sh
+++ b/infra/scripts/post_deployment.sh
@@ -337,3 +337,27 @@ if [ -n "$CU_ACCOUNT_NAME" ]; then
     echo "     az error: $CU_UPDATE_ERR"
   fi
 fi
+
+# --- Grant the deploying user Container Apps Contributor on the resource group ---
+# Direct (non-group) User assignment so Easy Auth's on-behalf listSecrets validation
+# can resolve RBAC when the Microsoft identity provider is added (avoids group token-overage).
+echo ""
+echo "Granting Container Apps Contributor to the deploying user on the resource group..."
+
+DEPLOYER_OBJECT_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)
+
+if [ -z "$DEPLOYER_OBJECT_ID" ] || [ -z "$RESOURCE_GROUP" ]; then
+  echo "  ⚠️ Missing signed-in user id or resource group. Skipping role assignment."
+else
+  RG_SCOPE="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
+  set +e  # set -e (top of script) would abort on a non-zero az exit
+  ROLE_ERR=$(az role assignment create --assignee-object-id "$DEPLOYER_OBJECT_ID" --assignee-principal-type User \
+    --role "358470bc-b998-42bd-ab17-a7e34c199c0f" --scope "$RG_SCOPE" --output none 2>&1)
+  ROLE_EC=$?
+  set -e
+  if [ $ROLE_EC -eq 0 ] || echo "$ROLE_ERR" | grep -qiE 'RoleAssignmentExists|already exists'; then
+    echo "  ✅ Container Apps Contributor granted to the deploying user."
+  else
+    echo "  ⚠️ Could not create the role assignment (non-fatal). az error: $ROLE_ERR"
+  fi
+fi

--- a/infra/scripts/post_deployment.sh
+++ b/infra/scripts/post_deployment.sh
@@ -345,9 +345,13 @@ echo ""
 echo "Granting Container Apps Contributor to the deploying user on the resource group..."
 
 DEPLOYER_OBJECT_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)
+# azd env may not populate AZURE_SUBSCRIPTION_ID in every shell; fall back to the CLI context.
+if [ -z "$SUBSCRIPTION_ID" ]; then
+  SUBSCRIPTION_ID=$(az account show --query id -o tsv 2>/dev/null || true)
+fi
 
-if [ -z "$DEPLOYER_OBJECT_ID" ] || [ -z "$RESOURCE_GROUP" ]; then
-  echo "  ⚠️ Missing signed-in user id or resource group. Skipping role assignment."
+if [ -z "$DEPLOYER_OBJECT_ID" ] || [ -z "$SUBSCRIPTION_ID" ] || [ -z "$RESOURCE_GROUP" ]; then
+  echo "  ⚠️ Missing signed-in user id, subscription id, or resource group. Skipping role assignment."
 else
   RG_SCOPE="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
   set +e  # set -e (top of script) would abort on a non-zero az exit

--- a/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
+++ b/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
@@ -47,7 +47,7 @@ async def get_async_bearer_token_provider():
     Returns:
         A callable suitable for SDK clients that accept a token provider.
     """
-    credential = await get_async_azure_credential()
+    credential = get_async_azure_credential()
     return identity_get_async_bearer_token_provider(
         credential, "https://cognitiveservices.azure.com/.default"
     )
@@ -195,7 +195,17 @@ def get_async_azure_credential():
     logging.info(
         "[AUTH] All async CLI credentials failed - falling back to AsyncDefaultAzureCredential"
     )
-    return AsyncDefaultAzureCredential()
+    app_env = os.getenv("APP_ENV", "prod").lower()
+    if app_env == "dev":
+        print("[AUTH] Environment: DEV -> using AsyncDefaultAzureCredential")
+        logging.info("[AUTH] APP_ENV=dev -> using AsyncDefaultAzureCredential")
+        return AsyncDefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
+    else:
+        print(f"[AUTH] Environment: PROD (APP_ENV={app_env}) -> using AsyncManagedIdentityCredential")
+        logging.info(
+            "[AUTH] APP_ENV=%s -> using AsyncManagedIdentityCredential", app_env
+        )
+        return AsyncManagedIdentityCredential(client_id=os.getenv("AZURE_CLIENT_ID"))
 
 
 def validate_azure_authentication() -> dict[str, Any]:

--- a/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
+++ b/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
@@ -191,9 +191,6 @@ def get_async_azure_credential():
         logging.info(f"[AUTH] Using {credential_name} for local development")
         return credential
 
-    # All async CLI credentials failed. Select the final credential based on the
-    # environment: production uses Managed Identity, while development uses
-    # DefaultAzureCredential. Defaults to production when APP_ENV is not set.
     app_env = os.getenv("APP_ENV", "prod").lower()
     if app_env == "prod":
         client_id = os.getenv("AZURE_CLIENT_ID")

--- a/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
+++ b/src/ContentProcessor/src/libs/utils/azure_credential_utils.py
@@ -191,21 +191,27 @@ def get_async_azure_credential():
         logging.info(f"[AUTH] Using {credential_name} for local development")
         return credential
 
-    # Final fallback to DefaultAzureCredential
-    logging.info(
-        "[AUTH] All async CLI credentials failed - falling back to AsyncDefaultAzureCredential"
-    )
+    # All async CLI credentials failed. Select the final credential based on the
+    # environment: production uses Managed Identity, while development uses
+    # DefaultAzureCredential. Defaults to production when APP_ENV is not set.
     app_env = os.getenv("APP_ENV", "prod").lower()
-    if app_env == "dev":
-        print("[AUTH] Environment: DEV -> using AsyncDefaultAzureCredential")
-        logging.info("[AUTH] APP_ENV=dev -> using AsyncDefaultAzureCredential")
-        return AsyncDefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
-    else:
-        print(f"[AUTH] Environment: PROD (APP_ENV={app_env}) -> using AsyncManagedIdentityCredential")
+    if app_env == "prod":
+        client_id = os.getenv("AZURE_CLIENT_ID")
+        if client_id:
+            logging.info(
+                "[AUTH] APP_ENV=prod -> using async user-assigned managed identity: %s",
+                client_id,
+            )
+            return AsyncManagedIdentityCredential(client_id=client_id)
         logging.info(
-            "[AUTH] APP_ENV=%s -> using AsyncManagedIdentityCredential", app_env
+            "[AUTH] APP_ENV=prod -> using async system-assigned managed identity"
         )
-        return AsyncManagedIdentityCredential(client_id=os.getenv("AZURE_CLIENT_ID"))
+        return AsyncManagedIdentityCredential()
+
+    logging.info(
+        "[AUTH] APP_ENV=%s -> falling back to AsyncDefaultAzureCredential", app_env
+    )
+    return AsyncDefaultAzureCredential()  # CodeQL [SM05139] Okay use of DefaultAzureCredential as it is only used in development
 
 
 def validate_azure_authentication() -> dict[str, Any]:

--- a/src/ContentProcessor/src/libs/utils/credential_util.py
+++ b/src/ContentProcessor/src/libs/utils/credential_util.py
@@ -47,7 +47,7 @@ async def get_async_bearer_token_provider():
     Returns:
         A callable suitable for SDK clients that accept a token provider.
     """
-    credential = await get_async_azure_credential()
+    credential = get_async_azure_credential()
     return identity_get_async_bearer_token_provider(
         credential, "https://cognitiveservices.azure.com/.default"
     )

--- a/src/tests/ContentProcessor/utils/test_azure_credential_utils.py
+++ b/src/tests/ContentProcessor/utils/test_azure_credential_utils.py
@@ -98,7 +98,7 @@ class TestGetAsyncAzureCredential:
         side_effect=Exception("no azd"),
     )
     @patch(f"{MODULE}.AsyncAzureCliCredential", side_effect=Exception("no az"))
-    @patch.dict("os.environ", {}, clear=True)
+    @patch.dict("os.environ", {"APP_ENV": "dev"}, clear=True)
     def test_falls_back_to_async_default(
         self, mock_async_cli, mock_async_dev_cli, mock_async_default
     ):

--- a/src/tests/ContentProcessor/utils/test_azure_credential_utils_extended.py
+++ b/src/tests/ContentProcessor/utils/test_azure_credential_utils_extended.py
@@ -109,6 +109,7 @@ class TestAzureCredentialUtilsExtended:
         for key in ["WEBSITE_SITE_NAME", "AZURE_CLIENT_ID", "MSI_ENDPOINT",
                     "IDENTITY_ENDPOINT", "KUBERNETES_SERVICE_HOST"]:
             monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("APP_ENV", "dev")
 
         with patch('libs.utils.azure_credential_utils.AsyncAzureCliCredential') as mock_cli, \
              patch('libs.utils.azure_credential_utils.AsyncAzureDeveloperCliCredential') as mock_azd, \
@@ -149,10 +150,7 @@ class TestAzureCredentialUtilsExtended:
         """Test async bearer token provider creation"""
         monkeypatch.setenv("MSI_ENDPOINT", "http://localhost")
 
-        # Create an async mock
-        from unittest.mock import AsyncMock
-
-        with patch('libs.utils.azure_credential_utils.get_async_azure_credential', new_callable=AsyncMock) as mock_get_cred, \
+        with patch('libs.utils.azure_credential_utils.get_async_azure_credential') as mock_get_cred, \
              patch('libs.utils.azure_credential_utils.identity_get_async_bearer_token_provider') as mock_provider:
 
             mock_credential = Mock()


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request updates how Azure credentials are selected and used in both application code and tests, with a particular focus on differentiating behavior based on the `APP_ENV` environment variable. The main change is to ensure that in production, the code prefers user-assigned or system-assigned managed identities, and only falls back to `AsyncDefaultAzureCredential` in development. Additionally, the way credentials are retrieved in async functions has been adjusted, and tests have been updated to reflect the new logic.

**Azure credential selection logic:**
- [`src/ContentProcessor/src/libs/utils/azure_credential_utils.py`](diffhunk://#diff-645da1ac7ca86603642f5ebbcdd4f2ee1ab6d8a113c2633c62b48e9a931a9665L194-R211): Changed `get_async_azure_credential()` to check `APP_ENV`; in production, it now uses user-assigned or system-assigned managed identity, and only falls back to `AsyncDefaultAzureCredential` in other environments. Improved logging to clarify credential selection.

**Async credential retrieval:**
- `src/ContentProcessor/src/libs/utils/azure_credential_utils.py` and `src/ContentProcessor/src/libs/utils/credential_util.py`: Updated `get_async_bearer_token_provider()` to call `get_async_azure_credential()` synchronously instead of awaiting it, reflecting that the credential function is no longer async. [[1]](diffhunk://#diff-645da1ac7ca86603642f5ebbcdd4f2ee1ab6d8a113c2633c62b48e9a931a9665L50-R50) [[2]](diffhunk://#diff-a7942413aee42bd72607dee0ae63400cd40ad2f473e1affc2901ffba6e2e22faL50-R50)

**Test updates:**
- [`src/tests/ContentProcessor/utils/test_azure_credential_utils.py`](diffhunk://#diff-8ca57e170c6b36142670ebcbbb5a7a96e2281b78f0f54696ccfd77b992e18b64L101-R101): Updated tests to set `APP_ENV` to "dev" to match the new credential selection logic.
- [`src/tests/ContentProcessor/utils/test_azure_credential_utils_extended.py`](diffhunk://#diff-646c63816deb0a09c29ba89982f07e0460b2700146dd52587d9046ea0809e4d0R112): Set `APP_ENV` to "dev" in relevant tests and updated mocks to match the new (non-async) credential retrieval. [[1]](diffhunk://#diff-646c63816deb0a09c29ba89982f07e0460b2700146dd52587d9046ea0809e4d0R112) [[2]](diffhunk://#diff-646c63816deb0a09c29ba89982f07e0460b2700146dd52587d9046ea0809e4d0L152-R153)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

