### PR TITLE
fix: Identity provider authentication issue resolved

### DIFF
--- a/infra/scripts/post_deployment.ps1
+++ b/infra/scripts/post_deployment.ps1
@@ -318,8 +318,10 @@ Write-Host ""
 Write-Host "Granting Container Apps Contributor to the deploying user on the resource group..."
 
 $DeployerObjectId = az ad signed-in-user show --query id -o tsv 2>$null
-if (-not $DeployerObjectId -or -not $RESOURCE_GROUP) {
-    Write-Host "  [Warn] Missing signed-in user id or resource group. Skipping role assignment."
+# azd env may not populate AZURE_SUBSCRIPTION_ID in every shell; fall back to the CLI context.
+if (-not $SUBSCRIPTION_ID) { $SUBSCRIPTION_ID = az account show --query id -o tsv 2>$null }
+if (-not $DeployerObjectId -or -not $SUBSCRIPTION_ID -or -not $RESOURCE_GROUP) {
+    Write-Host "  [Warn] Missing signed-in user id, subscription id, or resource group. Skipping role assignment."
 } else {
     $RgScope = "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
     $RoleOutput = az role assignment create --assignee-object-id $DeployerObjectId --assignee-principal-type User `

--- a/infra/scripts/post_deployment.ps1
+++ b/infra/scripts/post_deployment.ps1
@@ -310,3 +310,23 @@ if ($CU_ACCOUNT_NAME) {
         Write-Host "         az error: $UpdateOutputStr"
     }
 }
+
+# --- Grant the deploying user Container Apps Contributor on the resource group ---
+# Direct (non-group) User assignment so Easy Auth's on-behalf listSecrets validation
+# can resolve RBAC when the Microsoft identity provider is added (avoids group token-overage).
+Write-Host ""
+Write-Host "Granting Container Apps Contributor to the deploying user on the resource group..."
+
+$DeployerObjectId = az ad signed-in-user show --query id -o tsv 2>$null
+if (-not $DeployerObjectId -or -not $RESOURCE_GROUP) {
+    Write-Host "  [Warn] Missing signed-in user id or resource group. Skipping role assignment."
+} else {
+    $RgScope = "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
+    $RoleOutput = az role assignment create --assignee-object-id $DeployerObjectId --assignee-principal-type User `
+        --role "358470bc-b998-42bd-ab17-a7e34c199c0f" --scope $RgScope --output none 2>&1
+    if ($LASTEXITCODE -eq 0 -or ($RoleOutput | Out-String) -match '(?i)RoleAssignmentExists|already exists') {
+        Write-Host "  [OK] Container Apps Contributor granted to the deploying user."
+    } else {
+        Write-Host "  [Warn] Could not create the role assignment (non-fatal). az error: $(($RoleOutput | Out-String).Trim())"
+    }
+}

--- a/infra/scripts/post_deployment.sh
+++ b/infra/scripts/post_deployment.sh
@@ -337,3 +337,27 @@ if [ -n "$CU_ACCOUNT_NAME" ]; then
     echo "     az error: $CU_UPDATE_ERR"
   fi
 fi
+
+# --- Grant the deploying user Container Apps Contributor on the resource group ---
+# Direct (non-group) User assignment so Easy Auth's on-behalf listSecrets validation
+# can resolve RBAC when the Microsoft identity provider is added (avoids group token-overage).
+echo ""
+echo "Granting Container Apps Contributor to the deploying user on the resource group..."
+
+DEPLOYER_OBJECT_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)
+
+if [ -z "$DEPLOYER_OBJECT_ID" ] || [ -z "$RESOURCE_GROUP" ]; then
+  echo "  ⚠️ Missing signed-in user id or resource group. Skipping role assignment."
+else
+  RG_SCOPE="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
+  set +e  # set -e (top of script) would abort on a non-zero az exit
+  ROLE_ERR=$(az role assignment create --assignee-object-id "$DEPLOYER_OBJECT_ID" --assignee-principal-type User \
+    --role "358470bc-b998-42bd-ab17-a7e34c199c0f" --scope "$RG_SCOPE" --output none 2>&1)
+  ROLE_EC=$?
+  set -e
+  if [ $ROLE_EC -eq 0 ] || echo "$ROLE_ERR" | grep -qiE 'RoleAssignmentExists|already exists'; then
+    echo "  ✅ Container Apps Contributor granted to the deploying user."
+  else
+    echo "  ⚠️ Could not create the role assignment (non-fatal). az error: $ROLE_ERR"
+  fi
+fi

--- a/infra/scripts/post_deployment.sh
+++ b/infra/scripts/post_deployment.sh
@@ -345,9 +345,13 @@ echo ""
 echo "Granting Container Apps Contributor to the deploying user on the resource group..."
 
 DEPLOYER_OBJECT_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)
+# azd env may not populate AZURE_SUBSCRIPTION_ID in every shell; fall back to the CLI context.
+if [ -z "$SUBSCRIPTION_ID" ]; then
+  SUBSCRIPTION_ID=$(az account show --query id -o tsv 2>/dev/null || true)
+fi
 
-if [ -z "$DEPLOYER_OBJECT_ID" ] || [ -z "$RESOURCE_GROUP" ]; then
-  echo "  ⚠️ Missing signed-in user id or resource group. Skipping role assignment."
+if [ -z "$DEPLOYER_OBJECT_ID" ] || [ -z "$SUBSCRIPTION_ID" ] || [ -z "$RESOURCE_GROUP" ]; then
+  echo "  ⚠️ Missing signed-in user id, subscription id, or resource group. Skipping role assignment."
 else
   RG_SCOPE="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
   set +e  # set -e (top of script) would abort on a non-zero az exit


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request updates the deployment scripts to automatically grant the deploying user the "Container Apps Contributor" role on the resource group. This direct user assignment ensures that Easy Auth's on-behalf listSecrets validation can resolve RBAC when the Microsoft identity provider is added, and avoids issues related to group token overage.

Role assignment automation:

* Added logic to both `post_deployment.ps1` (PowerShell) and `post_deployment.sh` (Bash) scripts to grant the deploying user the "Container Apps Contributor" role directly on the resource group after deployment. This includes checks for required variables and handles cases where the assignment already exists or cannot be created, logging appropriate messages. [[1]](diffhunk://#diff-dbeece5fe68b590b88e37ac955ffd02a51fa6a282ca985d453e99537042ae3dcR313-R332) [[2]](diffhunk://#diff-1e4234fe6522e45d116dea4a258ba6926ff3215da41eb72362329316ee0c4fb0R340-R363)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

